### PR TITLE
Check if the keyboard is active from the Webview plugin

### DIFF
--- a/plugins/Android/src/net/gree/unitywebview/WebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/WebViewPlugin.java
@@ -94,6 +94,25 @@ public class WebViewPlugin
 			webSettings.setPluginsEnabled(true);
 
 		}});
+
+		final View activityRootView = a.getWindow().getDecorView().getRootView();
+		activityRootView.getViewTreeObserver().addOnGlobalLayoutListener(new android.view.ViewTreeObserver.OnGlobalLayoutListener() {
+		@Override
+		public void onGlobalLayout() {
+				android.graphics.Rect r = new android.graphics.Rect();
+				//r will be populated with the coordinates of your view that area still visible.
+				activityRootView.getWindowVisibleDisplayFrame(r);
+				android.view.Display display = a.getWindowManager().getDefaultDisplay();
+				int screenHeight = display.getHeight();
+				int heightDiff = activityRootView.getRootView().getHeight() - (r.bottom - r.top);
+				//System.out.print(String.format("[NativeWebview] %d, %d\n", screenHeight, heightDiff));
+				if (heightDiff > screenHeight/3) { // assume that this means that the keyboard is on
+					UnityPlayer.UnitySendMessage(gameObject, "SetKeyboardVisible", "true");
+				} else {
+					UnityPlayer.UnitySendMessage(gameObject, "SetKeyboardVisible", "false");
+				}
+			}
+		}); 
 	}
 
 	public void Destroy()

--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -52,8 +52,25 @@ public class WebViewObject : MonoBehaviour
 	IntPtr webView;
 #elif UNITY_ANDROID
 	AndroidJavaObject webView;
-	Vector2 offset;
+	
+	bool mIsKeyboardVisible = false;
+	
+	/// Called from Java native plugin to set when the keyboard is opened
+	public void SetKeyboardVisible(string pIsVisible)
+	{
+		mIsKeyboardVisible = (pIsVisible == "true");
+	}
 #endif
+	
+	public bool IsKeyboardVisible {
+		get {
+#if UNITY_ANDROID && !UNITY_EDITOR
+			return mIsKeyboardVisible;
+#else
+			return TouchScreenKeyboard.visible;
+#endif
+		}
+	}
 
 #if UNITY_EDITOR || UNITY_STANDALONE_OSX
 	[DllImport("WebView")]
@@ -123,7 +140,6 @@ public class WebViewObject : MonoBehaviour
 #elif UNITY_IPHONE
 		webView = _WebViewPlugin_Init(name);
 #elif UNITY_ANDROID
-		offset = new Vector2(0, 0);
 		webView = new AndroidJavaObject("net.gree.unitywebview.WebViewPlugin");
 		webView.Call("Init", name);
 #endif
@@ -176,7 +192,6 @@ public class WebViewObject : MonoBehaviour
 #elif UNITY_ANDROID
 		if (webView == null)
 			return;
-		offset = new Vector2(left, top);
 		webView.Call("SetMargins", left, top, right, bottom);
 #endif
 	}


### PR DESCRIPTION
- Unity's TouchScreenKeyboard.visible always returns false on Android when the keyboard is active from the plugin.
- With this fix, you'll be able to know when the soft keyboard has been opened in Android.
- For other platforms, it will just default to Unity's TouchScreenKeyboard.visible
