### PR TITLE
iOS , Android実機で出た不具合を修正

### DIFF
--- a/plugins/Android/src/net/gree/unitywebview/WebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/WebViewPlugin.java
@@ -61,6 +61,7 @@ public class WebViewPlugin
 {
 	private static FrameLayout layout = null;
 	private WebView mWebView;
+	private WebViewPluginInterface mWebViewPlugin;
 	private long mDownTime;
 
 	public WebViewPlugin()
@@ -103,13 +104,21 @@ public class WebViewPlugin
 						// Let webview handle the URL
 						return false;
 					}
+					else if(url.startsWith("unity:")){
+						String message = url.substring(6);
+						mWebViewPlugin.call(message);
+						return true;
+					}
 					Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
 					view.getContext().startActivity(intent);
 					return true;
 				}
 			});
+			
+			mWebViewPlugin = new WebViewPluginInterface(gameObject);
+			
 			mWebView.addJavascriptInterface(
-				new WebViewPluginInterface(gameObject), "Unity");
+				mWebViewPlugin , "Unity");
 
 			WebSettings webSettings = mWebView.getSettings();
 			webSettings.setSupportZoom(false);

--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -50,6 +50,8 @@ extern "C" void UnitySendMessage(const char *, const char *, const char *);
 - (void)dealloc
 {
 	[webView removeFromSuperview];
+	[webView release];
+    [super dealloc];
 }
 
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
@@ -139,6 +141,7 @@ void *_WebViewPlugin_Init(const char *gameObjectName)
 void _WebViewPlugin_Destroy(void *instance)
 {
 	WebViewPlugin *webViewPlugin = (__bridge_transfer WebViewPlugin *)instance;
+	[webViewPlugin release];
 	webViewPlugin = nil;
 }
 


### PR DESCRIPTION
# iOS
実機上で確認した所、親のUnityのGameObjectを破棄しても、
画面上にWebViewが残ってしまっていました。
それを修正し、GameObjectを破棄したらWebViewも破棄されるように致しました。

# Android
実機上で確認した所、unity:のSendMessageが効かないようでした。
それを使用できるように修正致しました。

ご検討のほど、よろしくお願い致します。