### PR TITLE
Android: Webview was not destroyed instantly, Webview did not report canGoBack/Forward as true

### DIFF
--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -124,7 +124,15 @@ public class CWebViewPlugin {
                 }
 
                 @Override
+                public void onLoadResource(WebView view, String url) {
+                    canGoBack = webView.canGoBack();
+                    canGoForward = webView.canGoForward();
+                }
+
+                @Override
                 public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                    canGoBack = webView.canGoBack();
+                    canGoForward = webView.canGoForward();
                     if (url.startsWith("http://") || url.startsWith("https://")
                         || url.startsWith("file://") || url.startsWith("javascript:")) {
                         // Let webview handle the URL

--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -203,7 +203,9 @@ public class CWebViewPlugin {
             if (mWebView == null) {
                 return;
             }
+            mWebView.stopLoading();
             layout.removeView(mWebView);
+            mWebView.destroy();
             mWebView = null;
         }});
     }


### PR DESCRIPTION
Android only fixes.

Webview was not destroyed instantly, if YouTube was playing it would continue to play in the background.

Webview did not report canGoBack/Forward true on all pages, for example YouTube. Added the check onLoadResource and shouldOverrideUrlLoading.
