### PR TITLE
added ssl error callback

### DIFF
--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -27,6 +27,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Point;
 import android.net.Uri;
+import android.net.http.SslError;
 import android.os.Build;
 import android.os.SystemClock;
 import android.util.Log;
@@ -40,6 +41,7 @@ import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
+import android.webkit.SslErrorHandler;
 import com.unity3d.player.UnityPlayer;
 
 class CWebViewPluginInterface {
@@ -108,6 +110,13 @@ public class CWebViewPlugin {
                     canGoBack = webView.canGoBack();
                     canGoForward = webView.canGoForward();
                     mWebViewPlugin.call("CallOnError", errorCode + "\t" + description + "\t" + failingUrl);
+                }
+                @Override
+                public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
+                    webView.loadUrl("about:blank");
+                    canGoBack = webView.canGoBack();
+                    canGoForward = webView.canGoForward();
+                    mWebViewPlugin.call("CallOnError", error.getPrimaryError() + "\t" + error.toString());
                 }
 
                 @Override


### PR DESCRIPTION
iOS is already capable for SSL error, but Android needed a particular callback.
The same callback method name "CallOnError" is used for this, because error code is not identified in any cases in current code.