### PR TITLE
Protecting against null pointer when scanning assemblies

### DIFF
--- a/plugins/Mac/Sources/WebView.m
+++ b/plugins/Mac/Sources/WebView.m
@@ -76,9 +76,12 @@ static void UnitySendMessage(
         
         monoAssembly =
             mono_domain_assembly_open(monoDomain, [assemblyPath UTF8String]);
-        monoImage = mono_assembly_get_image(monoAssembly);
+
+        if (monoAssembly != 0) {
+            monoImage = mono_assembly_get_image(monoAssembly);
+            monoMethod = mono_method_desc_search_in_image(monoDesc, monoImage);
+        }
         
-        monoMethod = mono_method_desc_search_in_image(monoDesc, monoImage);
         
         if (monoMethod == 0) {
             if (inEditor) {
@@ -92,8 +95,11 @@ static void UnitySendMessage(
             }
             monoAssembly =
                 mono_domain_assembly_open(monoDomain, [assemblyPath UTF8String]);
-            monoImage = mono_assembly_get_image(monoAssembly);
-            monoMethod = mono_method_desc_search_in_image(monoDesc, monoImage);
+
+            if (monoAssembly != 0) {
+                monoImage = mono_assembly_get_image(monoAssembly);
+                monoMethod = mono_method_desc_search_in_image(monoDesc, monoImage);
+            }
         }
     }
     


### PR DESCRIPTION
* If the assembly doesn't exist, mono_assembly_get_image will make a bad access with
  the monoAssembly pointer.  This bug was found working with Unity 5.5.2

* There could probably be some more null guards here, but I'm opting for the least
  amount of changes.  In Unity 5.5.2, this allows the call to succeed if you don't
  have a firstpass dll.