### PR TITLE
fixed to invoke webView.Call("EvaluateJS", js).

### DIFF
--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -535,7 +535,7 @@ public class WebViewObject : MonoBehaviour
 #elif UNITY_ANDROID
         if (webView == null)
             return;
-        webView.Call("LoadURL", "javascript:" + js);
+        webView.Call("EvaluateJS", js);
 #endif
     }
 


### PR DESCRIPTION
cf. https://github.com/gree/unity-webview/issues/241#issuecomment-382236745