### PR TITLE
jQuery3.0でsize()が削除されたのでその対応

### DIFF
--- a/WebPlayerTemplates/unity-webview/unity-webview.js
+++ b/WebPlayerTemplates/unity-webview/unity-webview.js
@@ -4,7 +4,7 @@ var unityWebView =
 
     init : function (name) {
         $containers = $('.webviewContainer');
-        if ($containers.size() === 0) {
+        if ($containers.length === 0) {
             $('<div class="webviewContainer" style="overflow:hidden; position:relative; width:100%; height:100%; top:-100%; pointer-events:none;"></div>')
                 .appendTo($('#unityPlayer'));
         }


### PR DESCRIPTION
**概要**
size()でエラーが出てinit()が完了できない。
その後loadURL()でcontentWindowがundefinedになる。

**原因**
jQuery3.0でsize()が削除されたため
https://api.jquery.com/size/

**対応**
size()をlengthで置き換えました。

よろしくお願いいたします。