### PR TITLE
Pass HTTP errors up to Unity

### DIFF
--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -35,6 +35,7 @@ import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebChromeClient;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -150,6 +151,13 @@ public class CWebViewPlugin {
                     canGoBack = webView.canGoBack();
                     canGoForward = webView.canGoForward();
                     mWebViewPlugin.call("CallOnError", errorCode + "\t" + description + "\t" + failingUrl);
+                }
+                
+                @Override
+                public void onReceivedHttpError(WebView view, WebResourceRequest request, WebResourceResponse errorResponse) {
+                	canGoBack = webView.canGoBack();
+                    canGoForward = webView.canGoForward();
+                    mWebViewPlugin.call("CallOnHttpError", Integer.toString(errorResponse.getStatusCode()));
                 }
 
                 @Override

--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -47,6 +47,7 @@ public class WebViewObject : MonoBehaviour
 {
     Callback onJS;
     Callback onError;
+    Callback onHttpError;
     Callback onStarted;
     Callback onLoaded;
     bool visibility;
@@ -328,12 +329,14 @@ public class WebViewObject : MonoBehaviour
         bool transparent = false,
         string ua = "",
         Callback err = null,
+        Callback httpErr = null,
         Callback ld = null,
         bool enableWKWebView = false,
         Callback started = null)
     {
         onJS = cb;
         onError = err;
+        onHttpError = httpErr;
         onStarted = started;
         onLoaded = ld;
 #if UNITY_WEBPLAYER
@@ -644,6 +647,14 @@ public class WebViewObject : MonoBehaviour
         if (onError != null)
         {
             onError(error);
+        }
+    }
+
+    public void CallOnHttpError(string error)
+    {
+        if (onHttpError != null)
+        {
+            onHttpError(error);
         }
     }
 

--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -323,6 +323,19 @@ extern "C" void UnitySendMessage(const char *, const char *, const char *);
     decisionHandler(WKNavigationActionPolicyAllow);
 }
 
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler {
+
+    if ([navigationResponse.response isKindOfClass:[NSHTTPURLResponse class]]) {
+
+        NSHTTPURLResponse * response = (NSHTTPURLResponse *)navigationResponse.response;
+        if (response.statusCode >= 400) {
+			UnitySendMessage([gameObjectName UTF8String], "CallOnHttpError", [[NSString stringWithFormat:@"%d", response.statusCode] UTF8String]);
+        }
+
+    }
+    decisionHandler(WKNavigationResponsePolicyAllow);
+}
+
 // alert
 - (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
 {


### PR DESCRIPTION
Pass HTTP errors up to Unity

The existing error callbacks only handle web resource loading errors, but consider e.g. a 404 to be a successful response.

既存のエラーコールバック関数は通信エラーに対応するが404などを成功と判定してしまうので、HTTPエラーをUnityに渡す機能を追加。