### PR TITLE
EditorとStandaloneでメモリリークが発生していたので修正

### DIFF
--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -401,6 +401,7 @@ public class WebViewObject : MonoBehaviour
             return;
         _CWebViewPlugin_Destroy(webView);
         webView = IntPtr.Zero;
+        Destroy(texture);
 #elif UNITY_IPHONE
         if (webView == IntPtr.Zero)
             return;


### PR DESCRIPTION
#### 概要
WebViewObjectの生成と破棄を繰り返すと使用メモリが増えていく（メモリリークが発生していた）
環境：Unity 2018.3.4f1

#### 原因
EditorおよびStandaloneで使用しているtextureがDestroyされていなかったため

#### 対応
OnDestroyのタイミングでtextureをDestroyするようにしました


よろしくお願いいたします