### PR TITLE
fix ios webview SetMargin issue

### DIFF
--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -279,7 +279,7 @@ public class WebViewObject : MonoBehaviour
     private static extern int _CWebViewPlugin_Destroy(IntPtr instance);
     [DllImport("__Internal")]
     private static extern void _CWebViewPlugin_SetMargins(
-        IntPtr instance, int left, int top, int right, int bottom);
+        IntPtr instance, float left, float top, float right, float bottom);
     [DllImport("__Internal")]
     private static extern void _CWebViewPlugin_SetVisibility(
         IntPtr instance, bool visibility);
@@ -324,7 +324,8 @@ public class WebViewObject : MonoBehaviour
     private static extern string _CWebViewPlugin_GetCookies(string url);
 #endif
 
-    public static bool IsWebViewAvailable() {
+    public static bool IsWebViewAvailable()
+    {
 #if !UNITY_EDITOR && UNITY_ANDROID
         return (new AndroidJavaObject("net.gree.unitywebview.CWebViewPlugin")).CallStatic<bool>("IsWebViewAvailable");
 #else
@@ -469,7 +470,11 @@ public class WebViewObject : MonoBehaviour
         _CWebViewPlugin_SetRect(webView, width, height);
         rect = new Rect(left, bottom, width, height);
 #elif UNITY_IPHONE
-        _CWebViewPlugin_SetMargins(webView, left, top, right, bottom);
+        float leftPercentage = left / Screen.width;
+        float topPercentage = top / Screen.height;
+        float rightPercentage = right / Screen.width;
+        float bottomPercentage = bottom / Screen.height;
+        _CWebViewPlugin_SetMargins(webView, leftPercentage, topPercentage, rightPercentage, bottomPercentage);
 #elif UNITY_ANDROID
         webView.Call("SetMargins", left, top, right, AdjustBottomMargin(bottom));
 #endif

--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -509,26 +509,24 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     webView.frame = frame;
 }
 
-- (void)setMargins:(int)left top:(int)top right:(int)right bottom:(int)bottom
+- (void)setMargins:(float)left top:(float)top right:(float)right bottom:(float)bottom
 {
     if (webView == nil)
         return;
     UIView *view = UnityGetGLViewController().view;
     CGRect frame = webView.frame;
     CGRect screen = view.bounds;
-    CGFloat scale = 1.0f / [self getScale:view];
-    frame.size.width = screen.size.width - scale * (left + right) ;
-    frame.size.height = screen.size.height - scale * (top + bottom) ;
-    frame.origin.x = scale * left ;
-    frame.origin.y = scale * top ;
+	CGFloat width = screen.size.width;
+	CGFloat height = screen.size.height;
+	CGFloat leftCG = CGFloat(left) * width;
+	CGFloat topCG = CGFloat(top) * height;
+	CGFloat rightCG = CGFloat(right) * height;
+	CGFloat bottomCG = CGFloat(bottom) * width;
+    frame.size.width = width - (leftCG + rightCG) ;
+    frame.size.height = height - (topCG + bottomCG) ;
+    frame.origin.x = leftCG ;
+    frame.origin.y = topCG ;
     webView.frame = frame;
-}
-
-- (CGFloat)getScale:(UIView *)view
-{
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0)
-        return view.window.screen.nativeScale;
-    return view.contentScaleFactor;
 }
 
 - (void)setVisibility:(BOOL)visibility
@@ -647,7 +645,7 @@ extern "C" {
     void _CWebViewPlugin_Destroy(void *instance);
     void _CWebViewPlugin_SetFrame(void* instace, int x, int y, int width, int height);
     void _CWebViewPlugin_SetMargins(
-        void *instance, int left, int top, int right, int bottom);
+        void *instance, float left, float top, float right, float bottom);
     void _CWebViewPlugin_SetVisibility(void *instance, BOOL visibility);
     void _CWebViewPlugin_LoadURL(void *instance, const char *url);
     void _CWebViewPlugin_LoadHTML(void *instance, const char *html, const char *baseUrl);
@@ -694,7 +692,7 @@ void _CWebViewPlugin_SetFrame(void* instance, int x, int y, int width, int heigh
 }
 
 void _CWebViewPlugin_SetMargins(
-    void *instance, int left, int top, int right, int bottom)
+    void *instance, float left, float top, float right, float bottom)
 {
     CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
     [webViewPlugin setMargins:left top:top right:right bottom:bottom];


### PR DESCRIPTION
When doing SetMargin on ios devices, the resolution is not correct.
The reason is that Screen.width, Screen.height in Unity and UnityGetGLViewController().view.bounds.size in WebView.mm do not match.