### PR TITLE
fixed to recreate layout if its parent differs from the current id.content.

### DIFF
--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -286,7 +286,7 @@ public class CWebViewPlugin {
                 webView.setBackgroundColor(0x00000000);
             }
 
-            if (layout == null) {
+            if (layout == null || layout.getParent() != a.findViewById(android.R.id.content)) {
                 layout = new FrameLayout(a);
                 a.addContentView(
                     layout,


### PR DESCRIPTION
cf. https://github.com/gree/unity-webview/issues/440#issuecomment-525646056