### PR TITLE
modified Rakefile to define UNITY as /Applications/UnityCurrent/Unity.app/Contents.

### DIFF
--- a/build/Rakefile
+++ b/build/Rakefile
@@ -20,7 +20,7 @@
 
 require 'fileutils'
 
-UNITY="/Applications/Unity/Unity.app/Contents"
+UNITY="/Applications/UnityCurrent/Unity.app/Contents"
 
 # NOTE: WebPlayerTemplates is not inclued for now because the sample app becomes complicated.
 #


### PR DESCRIPTION
The following for example is required:
`ln -s '/Applications/Unity/Hub/Editor/2019.2.11f1' /Applications/UnityCurrent`
