### PR TITLE
Adding support for WebGL

### DIFF
--- a/WebPlayerTemplates/unity-webview-webgl/index.html
+++ b/WebPlayerTemplates/unity-webview-webgl/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<title>Unity Web Player</title>
+
+		<link rel="shortcut icon" href="TemplateData/favicon.ico">
+		<link rel="stylesheet" href="TemplateData/style.css">
+		<script src="TemplateData/UnityProgress.js"></script>
+		<script src="Build/UnityLoader.js"></script>
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+
+		<script>
+			var gameInstance = UnityLoader.instantiate("gameContainer", "Build/WebGL-test.json", {onProgress: UnityProgress});
+		</script>
+	</head>
+	<body>
+		<div class="content">
+			<div class="webgl-content" id="unityPlayer">
+				<div id="gameContainer" style="width: 960px; height: 600px"></div>
+				<div class="footer">
+					<div class="webgl-logo"></div>
+					<div class="fullscreen" onclick="gameInstance.SetFullscreen(1)"></div>
+					<div class="title">Title</div>
+				</div>
+			</div>
+		</div>
+
+		<!-- unity_webview -->
+		<script type="text/javascript" src="unity-webview.js"></script>
+	</body>
+</html>

--- a/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
+++ b/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
@@ -5,7 +5,7 @@ var unityWebView =
     init : function (name) {
         $containers = $('.webviewContainer');
         if ($containers.length === 0) {
-            $('<div style="position: absolute; left: 0px; width: 100%; height: 100%;"><div class="webviewContainer" style="overflow:hidden; position:relative; width:100%; height:100%; top:-100%; pointer-events:none; z-index: 1;"></div></div')
+            $('<div style="position: absolute; left: 0px; width: 100%; height: 100%; top: 0px;"><div class="webviewContainer" style="overflow:hidden; position:relative; width:100%; height:100%; pointer-events:none; z-index: 1;"></div></div')
                 .appendTo($('#unityPlayer'));
         }
         var $last = $('.webviewContainer:last');

--- a/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
+++ b/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
@@ -1,4 +1,4 @@
-var unityWebView = 
+var unityWebView =
 {
     loaded: [],
 
@@ -41,7 +41,7 @@ var unityWebView =
                         return false;
                     }
                     return true;
-                }); 
+                });
             });
     },
 

--- a/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
+++ b/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
@@ -5,7 +5,7 @@ var unityWebView =
     init : function (name) {
         $containers = $('.webviewContainer');
         if ($containers.length === 0) {
-            $('<div style="position: absolute; left: 0px; width: 100%; height: 100%; top: 0px;"><div class="webviewContainer" style="overflow:hidden; position:relative; width:100%; height:100%; pointer-events:none; z-index: 1;"></div></div')
+            $('<div style="position: absolute; left: 0px; width: 100%; height: 100%;"><div class="webviewContainer" style="overflow:hidden; position:relative; width:100%; height:100%; top:-100%; pointer-events:none; z-index: 1;"></div></div')
                 .appendTo($('#unityPlayer'));
         }
         var $last = $('.webviewContainer:last');

--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -24,6 +24,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+#if UNITY_2018_4_OR_NEWER
+using UnityEngine.Networking;
+#endif
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
 using System.IO;
 using System.Text.RegularExpressions;
@@ -322,6 +325,19 @@ public class WebViewObject : MonoBehaviour
     private static extern void   _CWebViewPlugin_ClearCookies();
     [DllImport("__Internal")]
     private static extern string _CWebViewPlugin_GetCookies(string url);
+#elif UNITY_WEBGL
+	[DllImport("__Internal")]
+	private static extern void _gree_unity_webview_init(string name);
+	[DllImport("__Internal")]
+	private static extern void _gree_unity_webview_setMargins(string name, int left, int top, int right, int bottom);
+	[DllImport("__Internal")]
+	private static extern void _gree_unity_webview_setVisibility(string name, bool visible);
+	[DllImport("__Internal")]
+	private static extern void _gree_unity_webview_loadURL(string name, string url);
+	[DllImport("__Internal")]
+	private static extern void _gree_unity_webview_evaluateJS(string name, string js);
+	[DllImport("__Internal")]
+	private static extern void _gree_unity_webview_destroy(string name);
 #endif
 
     public static bool IsWebViewAvailable()
@@ -348,7 +364,9 @@ public class WebViewObject : MonoBehaviour
         onHttpError = httpErr;
         onStarted = started;
         onLoaded = ld;
-#if UNITY_WEBPLAYER
+#if UNITY_WEBGL
+        _gree_unity_webview_init(name);
+#elif UNITY_WEBPLAYER
         Application.ExternalCall("unityWebView.init", name);
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -400,7 +418,9 @@ public class WebViewObject : MonoBehaviour
 
     protected virtual void OnDestroy()
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBGL
+        _gree_unity_webview_destroy(name);
+#elif UNITY_WEBPLAYER
         Application.ExternalCall("unityWebView.destroy", name);
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -426,7 +446,7 @@ public class WebViewObject : MonoBehaviour
     /** Use this function instead of SetMargins to easily set up a centered window */
     public void SetCenterPositionWithScale(Vector2 center, Vector2 scale)
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -443,7 +463,7 @@ public class WebViewObject : MonoBehaviour
 
     public void SetMargins(int left, int top, int right, int bottom, bool relative = false)
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
 #elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
@@ -460,7 +480,9 @@ public class WebViewObject : MonoBehaviour
         mMarginTop = top;
         mMarginRight = right;
         mMarginBottom = bottom;
-#if UNITY_WEBPLAYER
+#if UNITY_WEBGL
+        _gree_unity_webview_setMargins(name, left, top, right, bottom);
+#elif UNITY_WEBPLAYER
         Application.ExternalCall("unityWebView.setMargins", name, left, top, right, bottom);
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -492,7 +514,9 @@ public class WebViewObject : MonoBehaviour
 
     public void SetVisibility(bool v)
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBGL
+        _gree_unity_webview_setVisibility(name, v);
+#elif UNITY_WEBPLAYER
         Application.ExternalCall("unityWebView.setVisibility", name, v);
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -522,7 +546,9 @@ public class WebViewObject : MonoBehaviour
     {
         if (string.IsNullOrEmpty(url))
             return;
-#if UNITY_WEBPLAYER
+#if UNITY_WEBGL
+        _gree_unity_webview_loadURL(name, url);
+#elif UNITY_WEBPLAYER
         Application.ExternalCall("unityWebView.loadURL", name, url);
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -543,7 +569,7 @@ public class WebViewObject : MonoBehaviour
             return;
         if (string.IsNullOrEmpty(baseUrl))
             baseUrl = "";
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -560,7 +586,9 @@ public class WebViewObject : MonoBehaviour
 
     public void EvaluateJS(string js)
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBGL
+        _gree_unity_webview_evaluateJS(name, js);
+#elif UNITY_WEBPLAYER
         Application.ExternalCall("unityWebView.evaluateJS", name, js);
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -577,7 +605,7 @@ public class WebViewObject : MonoBehaviour
 
     public int Progress()
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
         return 0;
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
@@ -596,7 +624,7 @@ public class WebViewObject : MonoBehaviour
 
     public bool CanGoBack()
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
         return false;
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
@@ -615,7 +643,7 @@ public class WebViewObject : MonoBehaviour
 
     public bool CanGoForward()
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
         return false;
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
@@ -634,7 +662,7 @@ public class WebViewObject : MonoBehaviour
 
     public void GoBack()
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -651,7 +679,7 @@ public class WebViewObject : MonoBehaviour
 
     public void GoForward()
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -703,8 +731,12 @@ public class WebViewObject : MonoBehaviour
         if (onJS != null)
         {
 #if !UNITY_ANDROID
+#if UNITY_2018_4_OR_NEWER
+            message = UnityWebRequest.UnEscapeURL(message);
+#else // UNITY_2018_4_OR_NEWER
             message = WWW.UnEscapeURL(message);
-#endif
+#endif // UNITY_2018_4_OR_NEWER
+#endif // !UNITY_ANDROID
             onJS(message);
         }
     }
@@ -712,7 +744,7 @@ public class WebViewObject : MonoBehaviour
 
     public void AddCustomHeader(string headerKey, string headerValue)
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -729,7 +761,7 @@ public class WebViewObject : MonoBehaviour
 
     public string GetCustomHeaderValue(string headerKey)
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
         return null;
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
@@ -748,7 +780,7 @@ public class WebViewObject : MonoBehaviour
 
     public void RemoveCustomHeader(string headerKey)
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
 #elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IPHONE
         if (webView == IntPtr.Zero)
@@ -763,7 +795,7 @@ public class WebViewObject : MonoBehaviour
 
     public void ClearCustomHeader()
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -780,7 +812,7 @@ public class WebViewObject : MonoBehaviour
 
     public void ClearCookies()
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
         //TODO: UNSUPPORTED
@@ -798,7 +830,7 @@ public class WebViewObject : MonoBehaviour
 
     public string GetCookies(string url)
     {
-#if UNITY_WEBPLAYER
+#if UNITY_WEBPLAYER || UNITY_WEBGL
         //TODO: UNSUPPORTED
         return "";
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN

--- a/plugins/unity-webview-webgl-plugin.jslib
+++ b/plugins/unity-webview-webgl-plugin.jslib
@@ -1,0 +1,25 @@
+mergeInto(LibraryManager.library, {
+	_gree_unity_webview_init: function(name) {
+		unityWebView.init(Pointer_stringify(name));
+	},
+
+	_gree_unity_webview_setMargins: function (name, left, top, right, bottom) {
+		unityWebView.setMargins(Pointer_stringify(name), left, top, right, bottom);
+	},
+
+	_gree_unity_webview_setVisibility: function(name, visible) {
+		unityWebView.setVisibility(Pointer_stringify(name), visible);
+	},
+
+	_gree_unity_webview_loadURL: function(name, url) {
+		unityWebView.loadURL(Pointer_stringify(name), Pointer_stringify(url));
+	},
+
+	_gree_unity_webview_evaluateJS: function(name, js) {
+		unityWebView.evaluateJS(Pointer_stringify(name), Pointer_stringify(js));
+	},
+
+	_gree_unity_webview_destroy: function(name) {
+		unityWebView.destroy(Pointer_stringify(name));
+	},
+});

--- a/sample/Assets/Scripts/SampleWebView.cs
+++ b/sample/Assets/Scripts/SampleWebView.cs
@@ -20,11 +20,19 @@
 
 using System.Collections;
 using UnityEngine;
+#if UNITY_2018_4_OR_NEWER
+using UnityEngine.UI;
+using UnityEngine.Networking;
+#endif
 
 public class SampleWebView : MonoBehaviour
 {
     public string Url;
+#if UNITY_2018_4_OR_NEWER
+    public Text status;
+#else
     public GUIText status;
+#endif
     WebViewObject webViewObject;
 
     IEnumerator Start()
@@ -102,7 +110,7 @@ public class SampleWebView : MonoBehaviour
         webViewObject.SetMargins(5, 100, 5, Screen.height / 4);
         webViewObject.SetVisibility(true);
 
-#if !UNITY_WEBPLAYER
+#if !UNITY_WEBPLAYER && !UNITY_WEBGL
         if (Url.StartsWith("http")) {
             webViewObject.LoadURL(Url.Replace(" ", "%20"));
         } else {
@@ -117,9 +125,15 @@ public class SampleWebView : MonoBehaviour
                 var dst = System.IO.Path.Combine(Application.persistentDataPath, url);
                 byte[] result = null;
                 if (src.Contains("://")) {  // for Android
+#if UNITY_2018_4_OR_NEWER
+                    var www = new UnityWebRequest(src);
+                    yield return www;
+                    result = www.downloadHandler.data;
+#else
                     var www = new WWW(src);
                     yield return www;
                     result = www.bytes;
+#endif
                 } else {
                     result = System.IO.File.ReadAllBytes(src);
                 }
@@ -148,7 +162,7 @@ public class SampleWebView : MonoBehaviour
         yield break;
     }
 
-#if !UNITY_WEBPLAYER
+#if !UNITY_WEBPLAYER && !UNITY_WEBGL
     void OnGUI()
     {
         GUI.enabled = webViewObject.CanGoBack();

--- a/sample/Assets/WebPlayerTemplates/unity-webview/unity-webview.js
+++ b/sample/Assets/WebPlayerTemplates/unity-webview/unity-webview.js
@@ -1,11 +1,11 @@
-var unityWebView = 
+var unityWebView =
 {
     loaded: [],
 
     init : function (name) {
         $containers = $('.webviewContainer');
         if ($containers.length === 0) {
-            $('<div style="position: absolute; left: 0px; width: 100%; height: 100%;"><div class="webviewContainer" style="overflow:hidden; position:relative; width:100%; height:100%; top:-100%; pointer-events:none; z-index: 1;"></div></div')
+            $('<div style="position: absolute; left: 0px; width: 100%; height: 100%; top: 0px;"><div class="webviewContainer" style="overflow:hidden; position:relative; width:100%; height:100%; pointer-events:none; z-index: 1;"></div></div')
                 .appendTo($('#unityPlayer'));
         }
         var $last = $('.webviewContainer:last');
@@ -41,7 +41,7 @@ var unityWebView =
                         return false;
                     }
                     return true;
-                }); 
+                });
             });
     },
 

--- a/sample/Assets/WebPlayerTemplates/unity-webview/unity-webview.js
+++ b/sample/Assets/WebPlayerTemplates/unity-webview/unity-webview.js
@@ -1,11 +1,11 @@
-var unityWebView =
+var unityWebView = 
 {
     loaded: [],
 
     init : function (name) {
         $containers = $('.webviewContainer');
         if ($containers.length === 0) {
-            $('<div style="position: absolute; left: 0px; width: 100%; height: 100%; top: 0px;"><div class="webviewContainer" style="overflow:hidden; position:relative; width:100%; height:100%; pointer-events:none; z-index: 1;"></div></div')
+            $('<div style="position: absolute; left: 0px; width: 100%; height: 100%;"><div class="webviewContainer" style="overflow:hidden; position:relative; width:100%; height:100%; top:-100%; pointer-events:none; z-index: 1;"></div></div')
                 .appendTo($('#unityPlayer'));
         }
         var $last = $('.webviewContainer:last');
@@ -41,7 +41,7 @@ var unityWebView =
                         return false;
                     }
                     return true;
-                });
+                }); 
             });
     },
 


### PR DESCRIPTION
Replaced several deprecated functions for Unity 2018.4 and above
Replaced JQuery load() with one() JQuery 3.1.0
Since Application.ExternalCall is deprecated, it is replaced with a middleman calling to a .jslib and then to the real script

---
Tested in Unity 2018.4.11f. Mainly substituting deprecated functions when it comes to UNITY_WEBGL.
I tried to not change the code too much. It runs fine in my project (displaying the website and sample.js running), although i can't guarantee it will run the same way as it is intended to since i didn't tested it with UnityWebPlayer beforehand (especially since i modified index.html and unity-webview.js).

I might miss or did something wrong, if so please let me know. Thank you.

---
Edit: Upon further testing, seems like several functions broke, such as 'u' and 'Unity' variable being undefined. Communicating is still an option by using other method (i'm using it on my project), but that'll change many of the existing code so, i'm not sure if i should do it.