### PR TITLE
Fixes for WebGL and Android

### DIFF
--- a/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
+++ b/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
@@ -24,7 +24,7 @@ var unityWebView =
                 contents.find('a').click(function (e) {
                     var href = $.trim($(this).attr('href'));
                     if (href.substr(0, 6) === 'unity:') {
-                        u.getUnity().SendMessage(name, "CallFromJS", href.substring(6, href.length));
+                        gameInstance.SendMessage(name, "CallFromJS", href.substring(6, href.length));
                         e.preventDefault();
                     } else {
                         w.location.replace(href);
@@ -39,7 +39,7 @@ var unityWebView =
                         if ($this.attr('method').toLowerCase() == 'get') {
                             message += '?' + $this.serialize();
                         }
-                        u.getUnity().SendMessage(name, "CallFromJS", message);
+                        gameInstance.getUnity().SendMessage(name, "CallFromJS", message);
                         return false;
                     }
                     return true;
@@ -48,7 +48,7 @@ var unityWebView =
     },
 
     sendMessage: function (name, message) {
-        u.getUnity().SendMessage(name, "CallFromJS", message);
+        gameInstance.getUnity().SendMessage(name, "CallFromJS", message);
     },
 
     setMargins: function (name, left, top, right, bottom) {

--- a/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
+++ b/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
@@ -5,7 +5,9 @@ var unityWebView =
     init : function (name) {
         $containers = $('.webviewContainer');
         if ($containers.length === 0) {
-            $('<div style="position: absolute; left: 0px; width: 100%; height: 100%;"><div class="webviewContainer" style="overflow:hidden; position:relative; width:100%; height:100%; top:-100%; pointer-events:none; z-index: 1;"></div></div')
+            $('<div style="position: absolute; left: 0px; width: 100%; height: 100%; top: 0px; pointer-events:none;">\
+            <div class="webviewContainer" style="overflow:hidden; position:relative; width:100%; height:100%; z-index: 1;">\
+            </div></div>')
                 .appendTo($('#unityPlayer'));
         }
         var $last = $('.webviewContainer:last');

--- a/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
+++ b/WebPlayerTemplates/unity-webview-webgl/unity-webview.js
@@ -17,7 +17,7 @@ var unityWebView =
             $('<iframe style="position:relative; width:100%; height100%; border-style:none; display:none; pointer-events:auto;"></iframe>')
             .attr('id', 'webview_' + name)
             .appendTo($last)
-            .one('load', function () {
+            .on('load', function () {
                 $(this).attr('loaded', 'true');
                 var contents = $(this).contents();
                 var w = $(this)[0].contentWindow;
@@ -84,7 +84,7 @@ var unityWebView =
         if ($iframe.attr('loaded') === 'true') {
             $iframe[0].contentWindow.eval(js);
         } else {
-            $iframe.one('load', function(){
+            $iframe.on('load', function(){
                 $(this)[0].contentWindow.eval(js);
             });
         }

--- a/sample/Assets/Scripts/SampleWebView.cs
+++ b/sample/Assets/Scripts/SampleWebView.cs
@@ -126,9 +126,17 @@ public class SampleWebView : MonoBehaviour
                 byte[] result = null;
                 if (src.Contains("://")) {  // for Android
 #if UNITY_2018_4_OR_NEWER
-                    var www = new UnityWebRequest(src);
-                    yield return www;
-                    result = www.downloadHandler.data;
+                    using (UnityWebRequest request = UnityWebRequest.Get(src))
+                    {
+                      yield return request.SendWebRequest();
+                      if (request.isHttpError || request.isNetworkError)
+                      {
+                        Debug.Log("An error has occured when trying to access " + src + ": " + request.error);
+                      } else
+                      {
+                        result = request.downloadHandler.data;
+                      }
+                    }
 #else
                     var www = new WWW(src);
                     yield return www;
@@ -137,7 +145,12 @@ public class SampleWebView : MonoBehaviour
                 } else {
                     result = System.IO.File.ReadAllBytes(src);
                 }
-                System.IO.File.WriteAllBytes(dst, result);
+
+                if (result != null)
+                {
+                  System.IO.File.WriteAllBytes(dst, result);
+                }
+
                 if (ext == ".html") {
                     webViewObject.LoadURL("file://" + dst.Replace(" ", "%20"));
                     break;


### PR DESCRIPTION
Fixes some issues:
- The missing u variable, i see it's already fixed on master though
- Fixed the missing Unity variable when loaded for the second time by changing one() to on()
- The frame positioning is also fixed, by moving "pointer-events: none" to the parent div
- Fixed the code for UnityWebRequest (i broke it last time, sorry. i hope nobody is affected badly)

UnityWebRequest part is tested on Android 9 and is running fine now.
The most important part is probably changing one() to on() and pointer-events: none
Everything else is i guess optional or already fixed.

Thank you.