### PR TITLE
Fix 3rd sdk WebView freeze randomly.

### DIFF
--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -531,11 +531,16 @@ public class CWebViewPlugin {
             if (mWebView == null) {
                 return;
             }
-            if (paused) {
-                mWebView.onPause();
-                mWebView.pauseTimers();
-            } else {
-                mWebView.onResume();
+            if (mWebView.getVisibility() == View.VISIBLE){
+                if (paused) {
+                    mWebView.onPause();
+                    //cf. https://qiita.com/nbhd/items/d31711faa8852143f3a4
+                    mWebView.pauseTimers();
+                } else {
+                    mWebView.onResume();
+                    mWebView.resumeTimers();
+                }
+            }else{
                 mWebView.resumeTimers();
             }
         }});


### PR DESCRIPTION
It was turn out that `mWebView.pauseTimers()` affects all application WebViews, which broke some 3rd sdk base on webview.

As unity framework, the js-timer controller should be limited in `mWebView.getVisibility() == View.VISIBLE` only.

Official ref:
https://developer.android.com/reference/android/webkit/WebView#pauseTimers()

> public void pauseTimers ()
> Pauses all layout, parsing, and JavaScript timers for all WebViews. This is a global requests, not restricted to just this WebView. This can be useful if the application has been paused.

Other ref:
https://qiita.com/nbhd/items/d31711faa8852143f3a4