### PR TITLE
Close the webview window when closing the webview

### DIFF
--- a/plugins/Mac/Sources/WebViewSeparated.m
+++ b/plugins/Mac/Sources/WebViewSeparated.m
@@ -111,6 +111,9 @@ static WKProcessPool *_sharedProcessPool;
             [webView stopLoading:nil];
             webView = nil;
         }
+        if (window != nil) {
+            [window close];
+        }
         gameObject = nil;
         bitmap = nil;
         window = nil;


### PR DESCRIPTION
No longer leave an empty window around after the webview is destroyed.