### PR TITLE
Add BASIC authentication feature (Android and iOS with WKWebView only)

### DIFF
--- a/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
@@ -36,6 +36,7 @@ import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.webkit.GeolocationPermissions.Callback;
+import android.webkit.HttpAuthHandler;
 import android.webkit.JavascriptInterface;
 import android.webkit.JsResult;
 import android.webkit.JsPromptResult;
@@ -101,6 +102,9 @@ public class CWebViewPlugin {
     private Pattern mAllowRegex;
     private Pattern mDenyRegex;
     private Pattern mHookRegex;
+
+    private String mBasicAuthUserName;
+    private String mBasicAuthPassword;
 
     public CWebViewPlugin() {
     }
@@ -281,6 +285,15 @@ public class CWebViewPlugin {
                 public void onLoadResource(WebView view, String url) {
                     canGoBack = webView.canGoBack();
                     canGoForward = webView.canGoForward();
+                }
+
+                @Override
+                public void onReceivedHttpAuthRequest(WebView view, HttpAuthHandler handler, String host, String realm) {
+                    if (mBasicAuthUserName != null && mBasicAuthPassword != null) {
+                        handler.proceed(mBasicAuthUserName, mBasicAuthPassword);
+                    } else {
+                        handler.cancel();
+                    }
                 }
 
                 @Override
@@ -655,5 +668,11 @@ public class CWebViewPlugin {
     {
         CookieManager cookieManager = CookieManager.getInstance();
         return cookieManager.getCookie(url);
+    }
+
+    public void SetBasicAuthInfo(final String userName, final String password)
+    {
+        mBasicAuthUserName = userName;
+        mBasicAuthPassword = password;
     }
 }

--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -40,6 +40,7 @@ import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.webkit.GeolocationPermissions.Callback;
+import android.webkit.HttpAuthHandler;
 import android.webkit.JavascriptInterface;
 import android.webkit.JsResult;
 import android.webkit.JsPromptResult;
@@ -119,6 +120,9 @@ public class CWebViewPlugin extends Fragment {
 
     private static long instanceCount;
     private long mInstanceId;
+
+    private String mBasicAuthUserName;
+    private String mBasicAuthPassword;
 
     public CWebViewPlugin() {
     }
@@ -444,6 +448,15 @@ public class CWebViewPlugin extends Fragment {
                 public void onLoadResource(WebView view, String url) {
                     canGoBack = webView.canGoBack();
                     canGoForward = webView.canGoForward();
+                }
+
+                @Override
+                public void onReceivedHttpAuthRequest(WebView view, HttpAuthHandler handler, String host, String realm) {
+                    if (mBasicAuthUserName != null && mBasicAuthPassword != null) {
+                        handler.proceed(mBasicAuthUserName, mBasicAuthPassword);
+                    } else {
+                        handler.cancel();
+                    }
                 }
 
                 @Override
@@ -825,5 +838,11 @@ public class CWebViewPlugin extends Fragment {
     {
         CookieManager cookieManager = CookieManager.getInstance();
         return cookieManager.getCookie(url);
+    }
+
+    public void SetBasicAuthInfo(final String userName, final String password)
+    {
+        mBasicAuthUserName = userName;
+        mBasicAuthPassword = password;
     }
 }

--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -344,6 +344,8 @@ public class WebViewObject : MonoBehaviour
     private static extern void   _CWebViewPlugin_SaveCookies();
     [DllImport("__Internal")]
     private static extern string _CWebViewPlugin_GetCookies(string url);
+    [DllImport("__Internal")]
+    private static extern void   _CWebViewPlugin_SetBasicAuthInfo(IntPtr instance, string userName, string password);
 #elif UNITY_WEBGL
 	[DllImport("__Internal")]
 	private static extern void _gree_unity_webview_init(string name);
@@ -975,6 +977,25 @@ public class WebViewObject : MonoBehaviour
 #else
         //TODO: UNSUPPORTED
         return "";
+#endif
+    }
+
+    public void SetBasicAuthInfo(string userName, string password)
+    {
+#if UNITY_WEBPLAYER || UNITY_WEBGL
+        //TODO: UNSUPPORTED
+#elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || UNITY_EDITOR_LINUX
+        //TODO: UNSUPPORTED
+#elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+        //TODO: UNSUPPORTED
+#elif UNITY_IPHONE
+        if (webView == IntPtr.Zero)
+            return;
+        _CWebViewPlugin_SetBasicAuthInfo(webView, userName, password);
+#elif UNITY_ANDROID
+        if (webView == null)
+            return;
+        webView.Call("SetBasicAuthInfo", userName, password);
 #endif
     }
 

--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -97,6 +97,8 @@ extern "C" void UnitySendMessage(const char *, const char *, const char *);
     NSRegularExpression *allowRegex;
     NSRegularExpression *denyRegex;
     NSRegularExpression *hookRegex;
+    NSString *basicAuthUserName;
+    NSString *basicAuthPassword;
 }
 @end
 
@@ -115,6 +117,8 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     allowRegex = nil;
     denyRegex = nil;
     hookRegex = nil;
+    basicAuthUserName = nil;
+    basicAuthPassword = nil;
     if (ua != NULL && strcmp(ua, "") != 0) {
         [[NSUserDefaults standardUserDefaults]
             registerDefaults:@{ @"UserAgent": [[NSString alloc] initWithUTF8String:ua] }];
@@ -174,6 +178,8 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
         [webView0 removeFromSuperview];
         [webView0 removeObserver:self forKeyPath:@"loading"];
     }
+    basicAuthPassword = nil;
+    basicAuthUserName = nil;
     hookRegex = nil;
     denyRegex = nil;
     allowRegex = nil;
@@ -452,6 +458,20 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     [UnityGetGLViewController() presentViewController:alertController animated:YES completion:^{}];
 }
 
+- (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+{
+    NSURLSessionAuthChallengeDisposition disposition;
+    NSURLCredential *credential;
+    if (basicAuthUserName && basicAuthPassword && [challenge previousFailureCount] == 0) {
+        disposition = NSURLSessionAuthChallengeUseCredential;
+        credential = [NSURLCredential credentialWithUser:basicAuthUserName password:basicAuthPassword persistence:NSURLCredentialPersistenceForSession];
+    } else {
+        disposition = NSURLSessionAuthChallengePerformDefaultHandling;
+        credential = nil;
+    }
+    completionHandler(disposition, credential);
+}
+
 - (BOOL)isSetupedCustomHeader:(NSURLRequest *)targetRequest
 {
     // Check for additional custom header.
@@ -669,6 +689,12 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     strcpy(r, s);
     return r;
 }
+
+- (void)setBasicAuthInfo:(const char *)userName password:(const char *)password
+{
+    basicAuthUserName = [NSString stringWithUTF8String:userName];
+    basicAuthPassword = [NSString stringWithUTF8String:password];
+}
 @end
 
 extern "C" {
@@ -695,6 +721,7 @@ extern "C" {
     void _CWebViewPlugin_SaveCookies();
     const char *_CWebViewPlugin_GetCookies(const char *url);
     const char *_CWebViewPlugin_GetCustomHeaderValue(void *instance, const char *headerKey);
+    void _CWebViewPlugin_SetBasicAuthInfo(void *instance, const char *userName, const char *password);
 }
 
 void *_CWebViewPlugin_Init(const char *gameObjectName, BOOL transparent, const char *ua, BOOL enableWKWebView)
@@ -866,6 +893,14 @@ const char *_CWebViewPlugin_GetCustomHeaderValue(void *instance, const char *hea
         return NULL;
     CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
     return [webViewPlugin getCustomRequestHeaderValue:headerKey];
+}
+
+void _CWebViewPlugin_SetBasicAuthInfo(void *instance, const char *userName, const char *password)
+{
+    if (instance == NULL)
+        return;
+    CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
+    [webViewPlugin setBasicAuthInfo:userName password:password];
 }
 
 #endif // !(__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)


### PR DESCRIPTION
Hi, committers,

Thank you for providing nice product. I use unity-webview to access a web site protected by BASIC authentication by adding 'Authorization' header with WebViewObject#AddCustomHeader() method. However, I noticed that this way did not work when 
 I sent POST request. (cf. https://github.com/gree/unity-webview/issues/394 )

So I wrote this pull request to resolve the problem for adding SetBasicAuthInfo() method to WebViewObject class. (currently it works only Android and iOS with WKWebView).

Could you consider if approve this pull request?

Regards,