### PR TITLE
Add reload feature

### DIFF
--- a/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
@@ -533,6 +533,16 @@ public class CWebViewPlugin {
         }});
     }
 
+    public void Reload() {
+        final Activity a = UnityPlayer.currentActivity;
+        a.runOnUiThread(new Runnable() {public void run() {
+            if (mWebView == null) {
+                return;
+            }
+            mWebView.reload();
+        }});
+    }
+
     public void SetMargins(int left, int top, int right, int bottom) {
         final FrameLayout.LayoutParams params
             = new FrameLayout.LayoutParams(

--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -722,6 +722,16 @@ public class CWebViewPlugin extends Fragment {
         }});
     }
 
+    public void Reload() {
+        final Activity a = UnityPlayer.currentActivity;
+        a.runOnUiThread(new Runnable() {public void run() {
+            if (mWebView == null) {
+                return;
+            }
+            mWebView.reload();
+        }});
+    }
+
     public void SetMargins(int left, int top, int right, int bottom) {
         final FrameLayout.LayoutParams params
             = new FrameLayout.LayoutParams(

--- a/plugins/Mac/Sources/WebView.mm
+++ b/plugins/Mac/Sources/WebView.mm
@@ -481,6 +481,13 @@ static std::unordered_map<int, int> _nskey2cgkey{
     [webView goForward];
 }
 
+- (void)reload
+{
+    if (webView == nil)
+        return;
+    [webView reload];
+}
+
 - (void)sendMouseEvent:(int)x y:(int)y deltaY:(float)deltaY mouseState:(int)mouseState
 {
     if (webView == nil)
@@ -752,6 +759,7 @@ extern "C" {
     BOOL _CWebViewPlugin_CanGoForward(void *instance);
     void _CWebViewPlugin_GoBack(void *instance);
     void _CWebViewPlugin_GoForward(void *instance);
+    void _CWebViewPlugin_Reload(void *instance);
     void _CWebViewPlugin_SendMouseEvent(void *instance, int x, int y, float deltaY, int mouseState);
     void _CWebViewPlugin_SendKeyEvent(void *instance, int x, int y, char *keyChars, unsigned short keyCode, int keyState);
     void _CWebViewPlugin_Update(void *instance, BOOL refreshBitmap);
@@ -870,6 +878,12 @@ void _CWebViewPlugin_GoForward(void *instance)
 {
     CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
     [webViewPlugin goForward];
+}
+
+void _CWebViewPlugin_Reload(void *instance)
+{
+    CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
+    [webViewPlugin reload];
 }
 
 void _CWebViewPlugin_SendMouseEvent(void *instance, int x, int y, float deltaY, int mouseState)

--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -200,6 +200,9 @@ public class WebViewObject : MonoBehaviour
     private static extern void _CWebViewPlugin_GoForward(
         IntPtr instance);
     [DllImport("WebView")]
+    private static extern void _CWebViewPlugin_Reload(
+        IntPtr instance);
+    [DllImport("WebView")]
     private static extern void _CWebViewPlugin_SendMouseEvent(IntPtr instance, int x, int y, float deltaY, int mouseState);
     [DllImport("WebView")]
     private static extern void _CWebViewPlugin_SendKeyEvent(IntPtr instance, int x, int y, string keyChars, ushort keyCode, int keyState);
@@ -268,6 +271,9 @@ public class WebViewObject : MonoBehaviour
         IntPtr instance);
     [DllImport("__Internal")]
     private static extern void _CWebViewPlugin_GoForward(
+        IntPtr instance);
+    [DllImport("__Internal")]
+    private static extern void _CWebViewPlugin_Reload(
         IntPtr instance);
     [DllImport("__Internal")]
     private static extern void   _CWebViewPlugin_AddCustomHeader(IntPtr instance, string headerKey, string headerValue);
@@ -741,6 +747,23 @@ public class WebViewObject : MonoBehaviour
         if (webView == null)
             return;
         webView.Call("GoForward");
+#endif
+    }
+
+    public void Reload()
+    {
+#if UNITY_WEBPLAYER || UNITY_WEBGL
+        //TODO: UNSUPPORTED
+#elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || UNITY_EDITOR_LINUX
+        //TODO: UNSUPPORTED
+#elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IPHONE
+        if (webView == IntPtr.Zero)
+            return;
+        _CWebViewPlugin_Reload(webView);
+#elif UNITY_ANDROID
+        if (webView == null)
+            return;
+        webView.Call("Reload");
 #endif
     }
 

--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -44,6 +44,7 @@ extern "C" void UnitySendMessage(const char *, const char *, const char *);
 @property (nonatomic, readonly) BOOL canGoForward;
 - (void)goBack;
 - (void)goForward;
+- (void)reload;
 - (void)stopLoading;
 - (void)setScrollBounce:(BOOL)enable;
 @end
@@ -654,6 +655,13 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     [webView goForward];
 }
 
+- (void)reload
+{
+    if (webView == nil)
+        return;
+    [webView reload];
+}
+
 - (void)addCustomRequestHeader:(const char *)headerKey value:(const char *)headerValue
 {
     NSString *keyString = [NSString stringWithUTF8String:headerKey];
@@ -714,6 +722,7 @@ extern "C" {
     BOOL _CWebViewPlugin_CanGoForward(void *instance);
     void _CWebViewPlugin_GoBack(void *instance);
     void _CWebViewPlugin_GoForward(void *instance);
+    void _CWebViewPlugin_Reload(void *instance);
     void _CWebViewPlugin_AddCustomHeader(void *instance, const char *headerKey, const char *headerValue);
     void _CWebViewPlugin_RemoveCustomHeader(void *instance, const char *headerKey);
     void _CWebViewPlugin_ClearCustomHeader(void *instance);
@@ -846,6 +855,14 @@ void _CWebViewPlugin_GoForward(void *instance)
         return;
     CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
     [webViewPlugin goForward];
+}
+
+void _CWebViewPlugin_Reload(void *instance)
+{
+    if (instance == NULL)
+        return;
+    CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
+    [webViewPlugin reload];
 }
 
 void _CWebViewPlugin_AddCustomHeader(void *instance, const char *headerKey, const char *headerValue)

--- a/plugins/iOS/WebViewWithUIWebView.mm
+++ b/plugins/iOS/WebViewWithUIWebView.mm
@@ -45,6 +45,7 @@ extern "C" void UnitySendMessage(const char *, const char *, const char *);
 @property (nonatomic, readonly) BOOL canGoForward;
 - (void)goBack;
 - (void)goForward;
+- (void)reload;
 - (void)stopLoading;
 - (void)setScrollBounce:(BOOL)enable;
 @end
@@ -756,6 +757,13 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     [webView goForward];
 }
 
+- (void)reload
+{
+    if (webView == nil)
+        return;
+    [webView reload];
+}
+
 - (void)addCustomRequestHeader:(const char *)headerKey value:(const char *)headerValue
 {
     NSString *keyString = [NSString stringWithUTF8String:headerKey];
@@ -816,6 +824,7 @@ extern "C" {
     BOOL _CWebViewPlugin_CanGoForward(void *instance);
     void _CWebViewPlugin_GoBack(void *instance);
     void _CWebViewPlugin_GoForward(void *instance);
+    void _CWebViewPlugin_Reload(void *instance);
     void _CWebViewPlugin_AddCustomHeader(void *instance, const char *headerKey, const char *headerValue);
     void _CWebViewPlugin_RemoveCustomHeader(void *instance, const char *headerKey);
     void _CWebViewPlugin_ClearCustomHeader(void *instance);
@@ -946,6 +955,14 @@ void _CWebViewPlugin_GoForward(void *instance)
         return;
     CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
     [webViewPlugin goForward];
+}
+
+void _CWebViewPlugin_Reload(void *instance)
+{
+    if (instance == NULL)
+        return;
+    CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
+    [webViewPlugin reload];
 }
 
 void _CWebViewPlugin_AddCustomHeader(void *instance, const char *headerKey, const char *headerValue)

--- a/sample/Assets/Scripts/SampleWebView.cs
+++ b/sample/Assets/Scripts/SampleWebView.cs
@@ -191,7 +191,11 @@ public class SampleWebView : MonoBehaviour
         }
         GUI.enabled = true;
 
-        GUI.TextField(new Rect(200, 10, 300, 80), "" + webViewObject.Progress());
+        if (GUI.Button(new Rect(200, 10, 80, 80), "r")) {
+            webViewObject.Reload();
+        }
+
+        GUI.TextField(new Rect(300, 10, 200, 80), "" + webViewObject.Progress());
 
         if (GUI.Button(new Rect(600, 10, 80, 80), "*")) {
             var g = GameObject.Find("WebViewObject");


### PR DESCRIPTION
Hi, committers,

Since unity-webview has no reload feature, `location.reload()` JavaScript function is usually used to reload. (cf. https://github.com/gree/unity-webview/issues/280)

However, the function has a critical problem in iOS. It sends a request with GET method even if original page was requested with POST method. (cf. https://qiita.com/sinri/items/5e609dfcce73e9bdc0d9)

So I think unity-webview should provide a native reload function.

Could you consider if approve this pull request?

Regards,