### PR TITLE
Fix a problem that custom User-Agent is ignored with WkWebView in specific case

### DIFF
--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -120,10 +120,6 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     hookRegex = nil;
     basicAuthUserName = nil;
     basicAuthPassword = nil;
-    if (ua != NULL && strcmp(ua, "") != 0) {
-        [[NSUserDefaults standardUserDefaults]
-            registerDefaults:@{ @"UserAgent": [[NSString alloc] initWithUTF8String:ua] }];
-    }
     UIView *view = UnityGetGLViewController().view;
     if (enableWKWebView && [WKWebView class]) {
         if (_sharedProcessPool == NULL) {
@@ -151,6 +147,9 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
         webView = [[WKWebView alloc] initWithFrame:view.frame configuration:configuration];
         webView.UIDelegate = self;
         webView.navigationDelegate = self;
+        if (ua != NULL && strcmp(ua, "") != 0) {
+            ((WKWebView *)webView).customUserAgent = [[NSString alloc] initWithUTF8String:ua];
+        }
     } else {
         webView = nil;
         return self;


### PR DESCRIPTION
Hi, committer,

I noticed that 'ua' parameter specified to WebViewObject#Init() was ignored with WkWebView in the case that wkContentMode isn't equal to 1 on iPad with iOS13+.

code to reproduce:
```
webViewObject.Init(
    ...,
    ua: "custom user agent string",
    wkContentMode: 0
);
```

Could you consider if approve this pull request?

Regards,