### PR TITLE
Software keyboard partially overlaps with WebView on Android with notch

### DIFF
--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -78,6 +78,7 @@ public class WebViewObject : MonoBehaviour
     
     bool mVisibility;
     bool mIsKeyboardVisible;
+    int mWindowVisibleDisplayFrameHeight;
     float mResumedTimestamp;
     
     void OnApplicationPause(bool paused)
@@ -135,7 +136,7 @@ public class WebViewObject : MonoBehaviour
                 using(AndroidJavaObject Rct = new AndroidJavaObject("android.graphics.Rect"))
                 {
                     View.Call("getWindowVisibleDisplayFrame", Rct);
-                    keyboardHeight = View.Call<int>("getHeight") - Rct.Call<int>("height");
+                    keyboardHeight = mWindowVisibleDisplayFrameHeight - Rct.Call<int>("height");
                 }
             }
             return (bottom > keyboardHeight) ? bottom : keyboardHeight;
@@ -396,6 +397,16 @@ public class WebViewObject : MonoBehaviour
 #elif UNITY_ANDROID
         webView = new AndroidJavaObject("net.gree.unitywebview.CWebViewPlugin");
         webView.Call("Init", name, transparent, ua);
+
+        using(AndroidJavaClass UnityClass = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+        {
+            AndroidJavaObject View = UnityClass.GetStatic<AndroidJavaObject>("currentActivity").Get<AndroidJavaObject>("mUnityPlayer").Call<AndroidJavaObject>("getView");
+            using(AndroidJavaObject Rct = new AndroidJavaObject("android.graphics.Rect"))
+            {
+                View.Call("getWindowVisibleDisplayFrame", Rct);
+                mWindowVisibleDisplayFrameHeight = Rct.Call<int>("height");
+            }
+        }
 #else
         Debug.LogError("Webview is not supported on this platform.");
 #endif


### PR DESCRIPTION
Hi, committers,

I found a problem that the software keyboard partially overlaps with WebView on Android with a notch (for example, [AQUOS 701SH](https://www.softbank.jp/mobile/support/product/aquos-r-compact/)).

The cause of this probmel is that `mUnityPlayer.getView().getHeight()` does not include the height of a notch, but `mUnityPlayer.getView().getWindowVisibleDisplayFrame().height()` includes the height of a notch.

Please accept this pull request if you think it is wotrh applying.

## Normal case

Scrolled up after displaying the software keyboard. The bottom of the page is completely displayed without overlapping.

![Normal case](https://user-images.githubusercontent.com/970766/102187982-14ff0180-3ef8-11eb-9301-e1252fae604e.png)

## Abnormal case

The bottom of the page is partially hidden since the software keyboard overlaps WebView.

![Screenshot_20201215-151526](https://user-images.githubusercontent.com/970766/102188324-82129700-3ef8-11eb-8c28-6ffe2878a2e0.png)

