### PR TITLE
Workaround for deadlock on Android KitKat

### DIFF
--- a/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
@@ -314,9 +314,12 @@ public class CWebViewPlugin {
                             urlCon.setRequestProperty("Authorization", "Basic " + Base64.encodeToString(authorization.getBytes(), Base64.NO_WRAP));
                         }
 
-                        String cookies = GetCookies(url);
-                        if (cookies != null && !cookies.isEmpty()) {
-                            urlCon.addRequestProperty("Cookie", cookies);
+                        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.KITKAT && Build.VERSION.SDK_INT != Build.VERSION_CODES.KITKAT_WATCH) {
+                            // cf. https://issuetracker.google.com/issues/36989494
+                            String cookies = GetCookies(url);
+                            if (cookies != null && !cookies.isEmpty()) {
+                                urlCon.addRequestProperty("Cookie", cookies);
+                            }
                         }
 
                         for (HashMap.Entry<String, String> entry: mCustomHeaders.entrySet()) {

--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -488,9 +488,12 @@ public class CWebViewPlugin extends Fragment {
                             urlCon.setRequestProperty("Authorization", "Basic " + Base64.encodeToString(authorization.getBytes(), Base64.NO_WRAP));
                         }
 
-                        String cookies = GetCookies(url);
-                        if (cookies != null && !cookies.isEmpty()) {
-                            urlCon.addRequestProperty("Cookie", cookies);
+                        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.KITKAT && Build.VERSION.SDK_INT != Build.VERSION_CODES.KITKAT_WATCH) {
+                            // cf. https://issuetracker.google.com/issues/36989494
+                            String cookies = GetCookies(url);
+                            if (cookies != null && !cookies.isEmpty()) {
+                                urlCon.addRequestProperty("Cookie", cookies);
+                            }
                         }
 
                         for (HashMap.Entry<String, String> entry: mCustomHeaders.entrySet()) {


### PR DESCRIPTION
Hi, committers,

I found a serious problem related to the pull request I sent and approved (https://github.com/gree/unity-webview/pull/628).

As discussed here https://issuetracker.google.com/issues/36989494 , deadlock occurs on KitKat if `CookieManager.getCookie()` is called in `WebViewClient.shouldInterceptRequest()`, and I made sure deadlock occured on KitKat device.

Unfortunately I could not a solution for the problem, however I made a patch as a poor workaround to avoid deadlock.

I hope you accept this pull request.

Regards,
