### PR TITLE
Fix deadlock problem on android 4.4.4

### DIFF
--- a/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
@@ -298,7 +298,7 @@ public class CWebViewPlugin {
                 }
 
                 @Override
-                public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+                public WebResourceResponse shouldInterceptRequest(WebView view, final String url) {
                     if (mCustomHeaders == null || mCustomHeaders.isEmpty()) {
                         return super.shouldInterceptRequest(view, url);
                     }
@@ -328,9 +328,18 @@ public class CWebViewPlugin {
 
                         urlCon.connect();
 
-                        List<String> setCookieHeaders = urlCon.getHeaderFields().get("Set-Cookie");
+                        final List<String> setCookieHeaders = urlCon.getHeaderFields().get("Set-Cookie");
                         if (setCookieHeaders != null) {
-                            SetCookies(url, setCookieHeaders);
+                            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT || Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT_WATCH) {
+                                // In addition to getCookie, setCookie cause deadlock on Android 4.4.4 cf. https://issuetracker.google.com/issues/36989494
+                                UnityPlayer.currentActivity.runOnUiThread(new Runnable() {
+                                    public void run() {
+                                        SetCookies(url, setCookieHeaders);
+                                    }
+                                });
+                            } else {
+                                SetCookies(url, setCookieHeaders);
+                            }
                         }
 
                         return new WebResourceResponse(

--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -472,7 +472,7 @@ public class CWebViewPlugin extends Fragment {
                 }
 
                 @Override
-                public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+                public WebResourceResponse shouldInterceptRequest(WebView view, final String url) {
                     if (mCustomHeaders == null || mCustomHeaders.isEmpty()) {
                         return super.shouldInterceptRequest(view, url);
                     }
@@ -502,9 +502,18 @@ public class CWebViewPlugin extends Fragment {
 
                         urlCon.connect();
 
-                        List<String> setCookieHeaders = urlCon.getHeaderFields().get("Set-Cookie");
+                        final List<String> setCookieHeaders = urlCon.getHeaderFields().get("Set-Cookie");
                         if (setCookieHeaders != null) {
-                            SetCookies(url, setCookieHeaders);
+                            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT || Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT_WATCH) {
+                                // In addition to getCookie, setCookie cause deadlock on Android 4.4.4 cf. https://issuetracker.google.com/issues/36989494
+                                UnityPlayer.currentActivity.runOnUiThread(new Runnable() {
+                                    public void run() {
+                                        SetCookies(url, setCookieHeaders);
+                                    }
+                                });
+                            } else {
+                                SetCookies(url, setCookieHeaders);
+                            }
                         }
 
                         return new WebResourceResponse(


### PR DESCRIPTION
Hi, committers,

I found the modification https://github.com/gree/unity-webview/pull/631 has still problem.

On Android 4.4.2, It works fine. But On Android 4.4.4, not only getCookie but setCookie causes deadlock.

I made sure this pull request work well on Android 4.4.2 and Android 4.4.4.

I am happy if you approve this.

Regards,
