### PR TITLE
[Android] Fix a problem about redirection which occurs by a request with custom header

### DIFF
--- a/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
@@ -305,6 +305,7 @@ public class CWebViewPlugin {
 
                     try {
                         HttpURLConnection urlCon = (HttpURLConnection) (new URL(url)).openConnection();
+                        urlCon.setInstanceFollowRedirects(false);
                         // The following should make HttpURLConnection have a same user-agent of webView)
                         // cf. http://d.hatena.ne.jp/faw/20070903/1188796959 (in Japanese)
                         urlCon.setRequestProperty("User-Agent", mWebViewUA);
@@ -327,6 +328,13 @@ public class CWebViewPlugin {
                         }
 
                         urlCon.connect();
+
+                        int responseCode = urlCon.getResponseCode();
+                        if (responseCode >= 300 && responseCode < 400) {
+                            // To avoid a problem due to a mismatch between requested URL and returned content,
+                            // make WebView request again in the case that redirection response was returned.
+                            return null;
+                        }
 
                         final List<String> setCookieHeaders = urlCon.getHeaderFields().get("Set-Cookie");
                         if (setCookieHeaders != null) {

--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -479,6 +479,7 @@ public class CWebViewPlugin extends Fragment {
 
                     try {
                         HttpURLConnection urlCon = (HttpURLConnection) (new URL(url)).openConnection();
+                        urlCon.setInstanceFollowRedirects(false);
                         // The following should make HttpURLConnection have a same user-agent of webView)
                         // cf. http://d.hatena.ne.jp/faw/20070903/1188796959 (in Japanese)
                         urlCon.setRequestProperty("User-Agent", mWebViewUA);
@@ -501,6 +502,13 @@ public class CWebViewPlugin extends Fragment {
                         }
 
                         urlCon.connect();
+
+                        int responseCode = urlCon.getResponseCode();
+                        if (responseCode >= 300 && responseCode < 400) {
+                            // To avoid a problem due to a mismatch between requested URL and returned content,
+                            // make WebView request again in the case that redirection response was returned.
+                            return null;
+                        }
 
                         final List<String> setCookieHeaders = urlCon.getHeaderFields().get("Set-Cookie");
                         if (setCookieHeaders != null) {


### PR DESCRIPTION
Hi, committers,

I found a problem that sometimes WebView did not render a web page correctly when a web server returned a redirection response to a request with custom headers on Android.

For details, please see: https://stackoverflow.com/questions/18237451/android-webviewclient-url-redirection-android-url-loading-system .

I have written a patch to fix it. I hope you approve this.

Regards,