### PR TITLE
Add ClearCache method

### DIFF
--- a/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
@@ -756,4 +756,15 @@ public class CWebViewPlugin {
         mBasicAuthUserName = userName;
         mBasicAuthPassword = password;
     }
+
+    public void ClearCache(final boolean includeDiskFiles)
+    {
+        final Activity a = UnityPlayer.currentActivity;
+        a.runOnUiThread(new Runnable() {public void run() {
+            if (mWebView == null) {
+                return;
+            }
+            mWebView.clearCache(includeDiskFiles);
+        }});
+    }
 }

--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -970,4 +970,15 @@ public class CWebViewPlugin extends Fragment {
         mBasicAuthUserName = userName;
         mBasicAuthPassword = password;
     }
+
+    public void ClearCache(final boolean includeDiskFiles)
+    {
+        final Activity a = UnityPlayer.currentActivity;
+        a.runOnUiThread(new Runnable() {public void run() {
+            if (mWebView == null) {
+                return;
+            }
+            mWebView.clearCache(includeDiskFiles);
+        }});
+    }
 }

--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -302,6 +302,8 @@ public class WebViewObject : MonoBehaviour
     private static extern string _CWebViewPlugin_GetCookies(string url);
     [DllImport("__Internal")]
     private static extern void   _CWebViewPlugin_SetBasicAuthInfo(IntPtr instance, string userName, string password);
+    [DllImport("__Internal")]
+    private static extern void   _CWebViewPlugin_ClearCache(IntPtr instance, bool includeDiskFiles);
 #elif UNITY_WEBGL
     [DllImport("__Internal")]
     private static extern void _gree_unity_webview_init(string name);
@@ -1047,6 +1049,23 @@ public class WebViewObject : MonoBehaviour
         if (webView == null)
             return;
         webView.Call("SetBasicAuthInfo", userName, password);
+#endif
+    }
+
+    public void ClearCache(bool includeDiskFiles)
+    {
+#if UNITY_WEBPLAYER || UNITY_WEBGL
+        //TODO: UNSUPPORTED
+#elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || UNITY_EDITOR_LINUX
+        //TODO: UNSUPPORTED
+#elif UNITY_IPHONE && !UNITY_EDITOR
+        if (webView == IntPtr.Zero)
+            return;
+        _CWebViewPlugin_ClearCache(webView, includeDiskFiles);
+#elif UNITY_ANDROID && !UNITY_EDITOR
+        if (webView == null)
+            return;
+        webView.Call("ClearCache", includeDiskFiles);
 #endif
     }
 

--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -721,6 +721,18 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     basicAuthUserName = [NSString stringWithUTF8String:userName];
     basicAuthPassword = [NSString stringWithUTF8String:password];
 }
+
+- (void)clearCache:(BOOL)includeDiskFiles
+{
+    if (webView == nil)
+        return;
+    NSMutableSet *types = [NSMutableSet setWithArray:@[WKWebsiteDataTypeMemoryCache]];
+    if (includeDiskFiles) {
+        [types addObject:WKWebsiteDataTypeDiskCache];
+    }
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:0];
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:types modifiedSince:date completionHandler:^{}];
+}
 @end
 
 extern "C" {
@@ -749,6 +761,7 @@ extern "C" {
     const char *_CWebViewPlugin_GetCookies(const char *url);
     const char *_CWebViewPlugin_GetCustomHeaderValue(void *instance, const char *headerKey);
     void _CWebViewPlugin_SetBasicAuthInfo(void *instance, const char *userName, const char *password);
+    void _CWebViewPlugin_ClearCache(void *instance, BOOL includeDiskFiles);
 }
 
 void *_CWebViewPlugin_Init(const char *gameObjectName, BOOL transparent, const char *ua, BOOL enableWKWebView, int contentMode)
@@ -948,6 +961,14 @@ void _CWebViewPlugin_SetBasicAuthInfo(void *instance, const char *userName, cons
         return;
     CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
     [webViewPlugin setBasicAuthInfo:userName password:password];
+}
+
+void _CWebViewPlugin_ClearCache(void *instance, BOOL includeDiskFiles)
+{
+    if (instance == NULL)
+        return;
+    CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
+    [webViewPlugin clearCache:includeDiskFiles];
 }
 
 #endif // !(__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)

--- a/plugins/iOS/WebViewWithUIWebView.mm
+++ b/plugins/iOS/WebViewWithUIWebView.mm
@@ -855,6 +855,7 @@ extern "C" {
     const char *_CWebViewPlugin_GetCookies(const char *url);
     const char *_CWebViewPlugin_GetCustomHeaderValue(void *instance, const char *headerKey);
     void _CWebViewPlugin_SetBasicAuthInfo(void *instance, const char *userName, const char *password);
+    void _CWebViewPlugin_ClearCache(void *instance, BOOL includeDiskFiles);
 }
 
 void *_CWebViewPlugin_Init(const char *gameObjectName, BOOL transparent, const char *ua, BOOL enableWKWebView, int contentMode)
@@ -1052,6 +1053,11 @@ void _CWebViewPlugin_SetBasicAuthInfo(void *instance, const char *userName, cons
         return;
     CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
     [webViewPlugin setBasicAuthInfo:userName password:password];
+}
+
+void _CWebViewPlugin_ClearCache(void *instance, BOOL includeDiskFiles)
+{
+    // no op
 }
 
 #endif // __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0


### PR DESCRIPTION
Hi, committers.

unity-webview does not have a method to clear cache, so I have added ClearCache(bool includeDiskFile) method.

For android, it calls WebView#clearCache(includeDiskFile).
cf. https://developer.android.com/reference/android/webkit/WebView#clearCache(boolean)

For iOS, it calls WKWebsiteDataStore#removeDataOfTypes method.
cf. https://developer.apple.com/documentation/webkit/wkwebsitedatastore/1532938-removedataoftypes?language=objc

(An implementation for UIWebView is empty because UIWebView is deprecated.)

I hope you approve this patch.

Regards,