### PR TITLE
Fix a problem that mailto link cannot be opened on Android.

### DIFF
--- a/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
@@ -381,29 +381,22 @@ public class CWebViewPlugin {
                     } else if (mHookRegex != null && mHookRegex.matcher(url).find()) {
                         mWebViewPlugin.call("CallOnHooked", url);
                         return true;
-                    }
-                    try {
-                        URL u = new URL(url);
-                        if (!u.getPath().toLowerCase().endsWith(".pdf")
-                            && (url.startsWith("http://")
-                                || url.startsWith("https://")
-                                || url.startsWith("file://")
-                                || url.startsWith("javascript:"))) {
-                            mWebViewPlugin.call("CallOnStarted", url);
-                            // Let webview handle the URL
-                            return false;
-                        }
-                        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                        PackageManager pm = a.getPackageManager();
-                        List<ResolveInfo> apps = pm.queryIntentActivities(intent, 0);
-                        if (apps.size() > 0) {
-                            view.getContext().startActivity(intent);
-                        }
-                        return true;
-                    } catch (java.net.MalformedURLException err) {
+                    } else if (!url.toLowerCase().endsWith(".pdf")
+                        && (url.startsWith("http://")
+                            || url.startsWith("https://")
+                            || url.startsWith("file://")
+                            || url.startsWith("javascript:"))) {
+                        mWebViewPlugin.call("CallOnStarted", url);
                         // Let webview handle the URL
                         return false;
                     }
+                    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                    PackageManager pm = a.getPackageManager();
+                    List<ResolveInfo> apps = pm.queryIntentActivities(intent, 0);
+                    if (apps.size() > 0) {
+                        view.getContext().startActivity(intent);
+                    }
+                    return true;
                 }
             });
             webView.addJavascriptInterface(mWebViewPlugin , "Unity");

--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -555,29 +555,22 @@ public class CWebViewPlugin extends Fragment {
                     } else if (mHookRegex != null && mHookRegex.matcher(url).find()) {
                         mWebViewPlugin.call("CallOnHooked", url);
                         return true;
-                    }
-                    try {
-                        URL u = new URL(url);
-                        if (!u.getPath().toLowerCase().endsWith(".pdf")
-                            && (url.startsWith("http://")
-                                || url.startsWith("https://")
-                                || url.startsWith("file://")
-                                || url.startsWith("javascript:"))) {
-                            mWebViewPlugin.call("CallOnStarted", url);
-                            // Let webview handle the URL
-                            return false;
-                        }
-                        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                        PackageManager pm = a.getPackageManager();
-                        List<ResolveInfo> apps = pm.queryIntentActivities(intent, 0);
-                        if (apps.size() > 0) {
-                            view.getContext().startActivity(intent);
-                        }
-                        return true;
-                    } catch (java.net.MalformedURLException err) {
+                    } else if (!url.toLowerCase().endsWith(".pdf")
+                        && (url.startsWith("http://")
+                            || url.startsWith("https://")
+                            || url.startsWith("file://")
+                            || url.startsWith("javascript:"))) {
+                        mWebViewPlugin.call("CallOnStarted", url);
                         // Let webview handle the URL
                         return false;
                     }
+                    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                    PackageManager pm = a.getPackageManager();
+                    List<ResolveInfo> apps = pm.queryIntentActivities(intent, 0);
+                    if (apps.size() > 0) {
+                        view.getContext().startActivity(intent);
+                    }
+                    return true;
                 }
             });
             webView.addJavascriptInterface(mWebViewPlugin , "Unity");


### PR DESCRIPTION
Hi, committers,

I have found a problem that mailto link could not be opened on Android.

The cause of this problem seems to be this modification: https://github.com/gree/unity-webview/pull/636 .

`new URL("mailto:xxx@xxx.com")` throws MalformedURLException because `mailto:xxx@.xxx.com`  is not valid as URL.

I am happy if you approve this pull request.

Regards,
