### PR TITLE
Hide iOS-specific code under UNITY_IOS define

### DIFF
--- a/plugins/Editor/UnityWebViewPostprocessBuild.cs
+++ b/plugins/Editor/UnityWebViewPostprocessBuild.cs
@@ -5,7 +5,9 @@ using System.Text;
 using System.Xml;
 using UnityEditor.Android;
 using UnityEditor.Callbacks;
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
+#endif
 using UnityEditor;
 using UnityEngine;
 
@@ -91,6 +93,7 @@ public class UnityWebViewPostprocessBuild
             }
         }
 #endif
+#if UNITY_IOS
         if (buildTarget == BuildTarget.iOS) {
             string projPath = path + "/Unity-iPhone.xcodeproj/project.pbxproj";
             PBXProject proj = new PBXProject();
@@ -102,6 +105,7 @@ public class UnityWebViewPostprocessBuild
 #endif
             File.WriteAllText(projPath, proj.WriteToString());
         }
+#endif
     }
 }
 


### PR DESCRIPTION
If Unity iOS package is not installed on the build machine, the build process fails with an error.

```
Library/PackageCache/net.gree.unity-webview@395ab13a96/Assets/Plugins/Editor/UnityWebViewPostprocessBuild.cs(8,19): error CS0234: The type or namespace name 'iOS' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)
```

This PR wraps iOS-specific code under UNITY_IOS preprocessor define, fixing the error.