### PR TITLE
Fix a problem that WebView's height not adjusted when software keyboard shown on tall Android device

### DIFF
--- a/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src-nofragment/net/gree/unitywebview/CWebViewPlugin.java
@@ -473,9 +473,18 @@ public class CWebViewPlugin {
                 } catch (java.lang.NoSuchMethodError err) {
                     h = display.getHeight();
                 }
-                int heightDiff = activityRootView.getRootView().getHeight() - (r.bottom - r.top);
-                //System.out.print(String.format("[NativeWebview] %d, %d\n", h, heightDiff));
-                if (heightDiff > h / 3) { // assume that this means that the keyboard is on
+
+                View rootView = activityRootView.getRootView();
+                int bottomPadding = 0;
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                    Point realSize = new Point();
+                    display.getRealSize(realSize); // this method was added at JELLY_BEAN_MR1
+                    int[] location = new int[2];
+                    rootView.getLocationOnScreen(location);
+                    bottomPadding = realSize.y - (location[1] + rootView.getHeight());
+                }
+                int heightDiff = rootView.getHeight() - (r.bottom - r.top);
+                if (heightDiff > 0 && (heightDiff + bottomPadding) > (h + bottomPadding) / 3) { // assume that this means that the keyboard is on
                     UnityPlayer.UnitySendMessage(gameObject, "SetKeyboardVisible", "true");
                 } else {
                     UnityPlayer.UnitySendMessage(gameObject, "SetKeyboardVisible", "false");

--- a/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/src/net/gree/unitywebview/CWebViewPlugin.java
@@ -647,9 +647,18 @@ public class CWebViewPlugin extends Fragment {
                 } catch (java.lang.NoSuchMethodError err) {
                     h = display.getHeight();
                 }
-                int heightDiff = activityRootView.getRootView().getHeight() - (r.bottom - r.top);
-                //System.out.print(String.format("[NativeWebview] %d, %d\n", h, heightDiff));
-                if (heightDiff > h / 3) { // assume that this means that the keyboard is on
+
+                View rootView = activityRootView.getRootView();
+                int bottomPadding = 0;
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                    Point realSize = new Point();
+                    display.getRealSize(realSize); // this method was added at JELLY_BEAN_MR1
+                    int[] location = new int[2];
+                    rootView.getLocationOnScreen(location);
+                    bottomPadding = realSize.y - (location[1] + rootView.getHeight());
+                }
+                int heightDiff = rootView.getHeight() - (r.bottom - r.top);
+                if (heightDiff > 0 && (heightDiff + bottomPadding) > (h + bottomPadding) / 3) { // assume that this means that the keyboard is on
                     UnityPlayer.UnitySendMessage(gameObject, "SetKeyboardVisible", "true");
                 } else {
                     UnityPlayer.UnitySendMessage(gameObject, "SetKeyboardVisible", "false");


### PR DESCRIPTION
Hi, committers.

I found a problem that a WebView's height was not adjusted when the software keyboard was shown on a tall android device.

The problem occurs in the case that an application is running as letter-box mode by satisfying the below condition:
- resizeableActivity=false on AndroidManifest.xml
- minSDKVersion <= 25
- maxAspectRatio is not specified on AndroidManifest.xml

( cf. https://developer.android.com/guide/practices/screens-distribution )

There is a large bottom padding below the application's view on a tall device, and the software keyboard overlaps the padding. Since the algorithm to detect showing software keyboard does not consider the padding, a WebView's height is not adjusted when the keyboard is shown.

To fix the problem, I've modified the algorithm.

This solution only works on Android 4.2 (Jelly Bean MR1) or higher because Display#getRealSize() was added at Jelly Bean MR1, but it may be no problem. I think there are no tall devices less than Android 4.2.

