### PR TITLE
fixed iOS setMargins() to set int values.

### DIFF
--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -554,16 +554,16 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     CGRect frame = webView.frame;
     CGRect screen = view.bounds;
     if (relative) {
-        frame.size.width = screen.size.width * (1.0f - left - right);
-        frame.size.height = screen.size.height * (1.0f - top - bottom);
-        frame.origin.x = screen.size.width * left;
-        frame.origin.y = screen.size.height * top;
+        frame.size.width = floor(screen.size.width * (1.0f - left - right));
+        frame.size.height = floor(screen.size.height * (1.0f - top - bottom));
+        frame.origin.x = floor(screen.size.width * left);
+        frame.origin.y = floor(screen.size.height * top);
     } else {
         CGFloat scale = 1.0f / [self getScale:view];
-        frame.size.width = screen.size.width - scale * (left + right) ;
-        frame.size.height = screen.size.height - scale * (top + bottom) ;
-        frame.origin.x = scale * left ;
-        frame.origin.y = scale * top ;
+        frame.size.width = floor(screen.size.width - scale * (left + right));
+        frame.size.height = floor(screen.size.height - scale * (top + bottom));
+        frame.origin.x = floor(scale * left);
+        frame.origin.y = floor(scale * top);
     }
     webView.frame = frame;
 }

--- a/plugins/iOS/WebViewWithUIWebView.mm
+++ b/plugins/iOS/WebViewWithUIWebView.mm
@@ -668,16 +668,16 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     CGRect frame = webView.frame;
     CGRect screen = view.bounds;
     if (relative) {
-        frame.size.width = screen.size.width * (1.0f - left - right);
-        frame.size.height = screen.size.height * (1.0f - top - bottom);
-        frame.origin.x = screen.size.width * left;
-        frame.origin.y = screen.size.height * top;
+        frame.size.width = floor(screen.size.width * (1.0f - left - right));
+        frame.size.height = floor(screen.size.height * (1.0f - top - bottom));
+        frame.origin.x = floor(screen.size.width * left);
+        frame.origin.y = floor(screen.size.height * top);
     } else {
         CGFloat scale = 1.0f / [self getScale:view];
-        frame.size.width = screen.size.width - scale * (left + right) ;
-        frame.size.height = screen.size.height - scale * (top + bottom) ;
-        frame.origin.x = scale * left ;
-        frame.origin.y = scale * top ;
+        frame.size.width = floor(screen.size.width - scale * (left + right));
+        frame.size.height = floor(screen.size.height - scale * (top + bottom));
+        frame.origin.x = floor(scale * left);
+        frame.origin.y = floor(scale * top);
     }
     webView.frame = frame;
 }


### PR DESCRIPTION
If non-integer values are used, the displayed content may be bounced when a user drags it even if the content width is equal to the scroll view width.