### PR TITLE
modified iOS implementation to enable allowFileAccessFromFileURLs/allowUniversalAccessFromFileURLs if UNITYWEBVIEW_IOS_ALLOW_FILE_URLS is defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ which new one (Assets/Plugins/iOS/WebView.mm) utilizes only WKWebView if iOS dep
 *NOTE: WKWebView is available since iOS8 but was largely changed in iOS9, so we use `___IPHONE_9_0` instead of `__IPHONE_8_0`*
 *NOTE: Several versions of Unity themselves also have the ITMS-90809 issue (cf. https://issuetracker.unity3d.com/issues/ios-apple-throws-deprecated-api-usage-warning-for-using-uiwebview-when-submitting-builds-to-the-app-store-connect ).*/
 
+#### XMLHttpRequest for file URLs
+
+WKWebView doesn't allow to access file URLs with XMLHttpRequest. This limitation can be relaxed by `allowFileAccessFromFileURLs`/`allowUniversalAccessFromFileURLs` settings. Those are however private APIs so currently disabled by default. For enabling them, please define `UNITYWEBVIEW_IOS_ALLOW_FILE_URLS`.
+
+cf. https://github.com/gree/unity-webview/issues/785
+cf. https://github.com/gree/unity-webview/issues/224#issuecomment-640642516
+
 ### Android
 
 #### File Input Field

--- a/plugins/Editor/UnityWebViewPostprocessBuild.cs
+++ b/plugins/Editor/UnityWebViewPostprocessBuild.cs
@@ -215,6 +215,13 @@ public class UnityWebViewPostprocessBuild
                 var method = type.GetMethod("AddFrameworkToProject");
                 method.Invoke(proj, new object[]{target, "WebKit.framework", false});
             }
+#if UNITYWEBVIEW_IOS_ALLOW_FILE_URLS
+            // proj.AddBuildProperty(target, "OTHER_LDFLAGS", "-DUNITYWEBVIEW_IOS_ALLOW_FILE_URLS");
+            {
+                var method = type.GetMethod("AddBuildProperty", new Type[]{typeof(string), typeof(string), typeof(string)});
+                method.Invoke(proj, new object[]{target, "OTHER_CFLAGS", "-DUNITYWEBVIEW_IOS_ALLOW_FILE_URLS"});
+            }
+#endif
             var dst = "";
             //dst = proj.WriteToString();
             {

--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -171,6 +171,19 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
         if (@available(iOS 13.0, *)) {
             configuration.defaultWebpagePreferences.preferredContentMode = contentMode;
         }
+#if UNITYWEBVIEW_IOS_ALLOW_FILE_URLS
+        // cf. https://stackoverflow.com/questions/35554814/wkwebview-xmlhttprequest-with-file-url/44365081#44365081
+        try {
+            [configuration.preferences setValue:@TRUE forKey:@"allowFileAccessFromFileURLs"];
+        }
+        catch (NSException *ex) {
+        }
+        try {
+            [configuration setValue:@TRUE forKey:@"allowUniversalAccessFromFileURLs"];
+        }
+        catch (NSException *ex) {
+        }
+#endif
         WKWebView *wkwebView = [[WKWebView alloc] initWithFrame:view.frame configuration:configuration];
         wkwebView.allowsLinkPreview = allowsLinkPreview;
         webView = wkwebView;

--- a/plugins/iOS/WebViewWithUIWebView.mm
+++ b/plugins/iOS/WebViewWithUIWebView.mm
@@ -223,6 +223,19 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
         if (@available(iOS 13.0, *)) {
             configuration.defaultWebpagePreferences.preferredContentMode = contentMode;
         }
+#if UNITYWEBVIEW_IOS_ALLOW_FILE_URLS
+        // cf. https://stackoverflow.com/questions/35554814/wkwebview-xmlhttprequest-with-file-url/44365081#44365081
+        try {
+            [configuration.preferences setValue:@TRUE forKey:@"allowFileAccessFromFileURLs"];
+        }
+        catch (NSException *ex) {
+        }
+        try {
+            [configuration setValue:@TRUE forKey:@"allowUniversalAccessFromFileURLs"];
+        }
+        catch (NSException *ex) {
+        }
+#endif
         WKWebView *wkwebView = [[WKWebView alloc] initWithFrame:view.frame configuration:configuration];
         wkwebView.allowsLinkPreview = allowsLinkPreview;
         webView = wkwebView;


### PR DESCRIPTION
cf. https://github.com/gree/unity-webview/issues/785
cf. https://github.com/gree/unity-webview/issues/224#issuecomment-640642516