### PR TITLE
introduced BottomAdjustmentDisabled() to disable bottom margin adjustment

### DIFF
--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -144,12 +144,12 @@ public class WebViewObject : MonoBehaviour
     /// Called from Java native plugin to set when the keyboard is opened
     public void SetKeyboardVisible(string pIsVisible)
     {
-        bool isKeyboardVisible0 = mIsKeyboardVisible;
-        mIsKeyboardVisible = (pIsVisible == "true");
-        if (!Screen.fullScreen)
+        if (BottomAdjustmentDisabled())
         {
             return;
         }
+        bool isKeyboardVisible0 = mIsKeyboardVisible;
+        mIsKeyboardVisible = (pIsVisible == "true");
         if (mIsKeyboardVisible != isKeyboardVisible0 || mIsKeyboardVisible)
         {
             SetMargins(mMarginLeft, mMarginTop, mMarginRight, mMarginBottom, mMarginRelative);
@@ -158,7 +158,11 @@ public class WebViewObject : MonoBehaviour
     
     public int AdjustBottomMargin(int bottom)
     {
-        if (!mIsKeyboardVisible || !Screen.fullScreen)
+        if (BottomAdjustmentDisabled())
+        {
+            return bottom;
+        }
+        else if (!mIsKeyboardVisible)
         {
             return bottom;
         }
@@ -176,6 +180,14 @@ public class WebViewObject : MonoBehaviour
             }
             return (bottom > keyboardHeight) ? bottom : keyboardHeight;
         }
+    }
+
+    private bool BottomAdjustmentDisabled()
+    {
+        return
+            !Screen.fullScreen
+            || ((Screen.autorotateToLandscapeLeft || Screen.autorotateToLandscapeRight)
+                && (Screen.autorotateToPortrait || Screen.autorotateToPortraitUpsideDown));
     }
 #else
     IntPtr webView;


### PR DESCRIPTION
cf. #807
cf. #729 

If rotation for both portrait and landscape is allowed, adjusting bottom margin makes the input field defocused while the keyboard is still visible. This behavior is odd and should be avoided, so we do not adjust bottom margin for this case.