### PR TITLE
fixed to explicitly set AnyCPU for OSXUnivdersal in WebView.bundle.meta.

### DIFF
--- a/plugins/Mac/WebView.bundle.meta
+++ b/plugins/Mac/WebView.bundle.meta
@@ -38,7 +38,8 @@ PluginImporter:
         CPU: AnyCPU
     OSXUniversal:
       enabled: 1
-      settings: {}
+      settings:
+        CPU: AnyCPU
     Win:
       enabled: 0
       settings:


### PR DESCRIPTION
cf. #828 
cf. #761