### PR TITLE
fixed to invoke startActivity() without queryIntentActivities() (for Android 11 or later).

### DIFF
--- a/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -22,6 +22,7 @@
 package net.gree.unitywebview;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -440,9 +441,13 @@ public class CWebViewPlugin {
                     }
                     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
                     PackageManager pm = a.getPackageManager();
-                    List<ResolveInfo> apps = pm.queryIntentActivities(intent, 0);
-                    if (apps.size() > 0) {
+                    // List<ResolveInfo> apps = pm.queryIntentActivities(intent, 0);
+                    // if (apps.size() > 0) {
+                    //     view.getContext().startActivity(intent);
+                    // }
+                    try {
                         view.getContext().startActivity(intent);
+                    } catch (ActivityNotFoundException ex) {
                     }
                     return true;
                 }

--- a/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -24,6 +24,7 @@ package net.gree.unitywebview;
 import android.Manifest;
 import android.app.Activity;
 import android.app.Fragment;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -609,10 +610,14 @@ public class CWebViewPlugin extends Fragment {
                         return false;
                     }
                     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                    PackageManager pm = a.getPackageManager();
-                    List<ResolveInfo> apps = pm.queryIntentActivities(intent, 0);
-                    if (apps.size() > 0) {
+                    // PackageManager pm = a.getPackageManager();
+                    // List<ResolveInfo> apps = pm.queryIntentActivities(intent, 0);
+                    // if (apps.size() > 0) {
+                    //     view.getContext().startActivity(intent);
+                    // }
+                    try {
                         view.getContext().startActivity(intent);
+                    } catch (ActivityNotFoundException ex) {
                     }
                     return true;
                 }


### PR DESCRIPTION
cf. https://github.com/gree/unity-webview/issues/180#issuecomment-1220015009
cf. https://techblog.locoguide.co.jp/entry/2020/09/23/150010
