### PR TITLE
Fix Destroy error in editor mode

### DIFF
--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -521,7 +521,14 @@ public class WebViewObject : MonoBehaviour
             return;
         _CWebViewPlugin_Destroy(webView);
         webView = IntPtr.Zero;
-        Destroy(texture);
+        if (Application.isPlaying)
+        {
+            Destroy(texture);
+        }
+        else
+        {
+            DestroyImmediate(texture);
+        }
 #elif UNITY_IPHONE
         if (webView == IntPtr.Zero)
             return;


### PR DESCRIPTION
I am using unity-webview on MacOS in editor mode with the following code.

```cs
[ExecuteAlways]
public class WebViewObject2: WebViewObject
{
    private void OnRenderObject()
    {
#if UNITY_EDITOR
        if (!Application.isPlaying)
        {
            EditorApplication.QueuePlayerLoopUpdate();
            SceneView.RepaintAll();
        }
#endif
    }
}
````

At the moment I get the following error when destroying, so I fixed it.

> Destroy may not be called from edit mode! Use DestroyImmediate instead. 
> Destroying an object in edit mode destroys it permanently.