### PR TITLE
fixed GetCookies to work with recent iOS/OSX and to invoke the 'cookes:' callback.

### DIFF
--- a/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -363,7 +363,7 @@ public class CWebViewPlugin {
 
                         if (Build.VERSION.SDK_INT != Build.VERSION_CODES.KITKAT && Build.VERSION.SDK_INT != Build.VERSION_CODES.KITKAT_WATCH) {
                             // cf. https://issuetracker.google.com/issues/36989494
-                            String cookies = GetCookies(url);
+                            String cookies = CookieManager.getInstance().getCookie(url);
                             if (cookies != null && !cookies.isEmpty()) {
                                 urlCon.addRequestProperty("Cookie", cookies);
                             }
@@ -950,10 +950,10 @@ public class CWebViewPlugin {
         }
     }
 
-    public String GetCookies(String url)
+    public void GetCookies(String url)
     {
         CookieManager cookieManager = CookieManager.getInstance();
-        return cookieManager.getCookie(url);
+        mWebViewPlugin.call("CallOnCookies", cookieManager.getCookie(url));
     }
 
     public void SetCookies(String url, List<String> setCookieHeaders)

--- a/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -650,7 +650,7 @@ public class CWebViewPlugin extends Fragment {
 
                         if (Build.VERSION.SDK_INT != Build.VERSION_CODES.KITKAT && Build.VERSION.SDK_INT != Build.VERSION_CODES.KITKAT_WATCH) {
                             // cf. https://issuetracker.google.com/issues/36989494
-                            String cookies = GetCookies(url);
+                            String cookies = CookieManager.getInstance().getCookie(url);
                             if (cookies != null && !cookies.isEmpty()) {
                                 urlCon.addRequestProperty("Cookie", cookies);
                             }
@@ -1343,10 +1343,10 @@ public class CWebViewPlugin extends Fragment {
         }
     }
 
-    public String GetCookies(String url)
+    public void GetCookies(String url)
     {
         CookieManager cookieManager = CookieManager.getInstance();
-        return cookieManager.getCookie(url);
+        mWebViewPlugin.call("CallOnCookies", cookieManager.getCookie(url));
     }
 
     public void SetCookies(String url, List<String> setCookieHeaders)

--- a/plugins/iOS/WebViewWithUIWebView.mm
+++ b/plugins/iOS/WebViewWithUIWebView.mm
@@ -306,8 +306,22 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     gameObjectName = nil;
 }
 
++ (void)resetSharedProcessPool
+{
+    // cf. https://stackoverflow.com/questions/33156567/getting-all-cookies-from-wkwebview/49744695#49744695
+    _sharedProcessPool = [[WKProcessPool alloc] init];
+    [_instances enumerateObjectsUsingBlock:^(CWebViewPlugin *obj, NSUInteger idx, BOOL *stop) {
+        if ([obj->webView isKindOfClass:[WKWebView class]]) {
+            WKWebView *webView = (WKWebView *)obj->webView;
+            webView.configuration.processPool = _sharedProcessPool;
+        }
+    }];
+}
+
 + (void)clearCookies
 {
+    [CWebViewPlugin resetSharedProcessPool];
+
     // cf. https://dev.classmethod.jp/smartphone/remove-webview-cookies/
     NSString *libraryPath = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES).firstObject;
     NSString *cookiesPath = [libraryPath stringByAppendingPathComponent:@"Cookies"];
@@ -326,6 +340,7 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
 
     NSOperatingSystemVersion version = { 9, 0, 0 };
     if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:version]) {
+        // cf. https://stackoverflow.com/questions/46465070/how-to-delete-cookies-from-wkhttpcookiestore/47928399#47928399
         NSSet *websiteDataTypes = [WKWebsiteDataStore allWebsiteDataTypes];
         NSDate *date = [NSDate dateWithTimeIntervalSince1970:0];
         [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes
@@ -336,58 +351,75 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
 
 + saveCookies
 {
-    // cf. https://stackoverflow.com/questions/33156567/getting-all-cookies-from-wkwebview/49744695#49744695
-    _sharedProcessPool = [[WKProcessPool alloc] init];
-    [_instances enumerateObjectsUsingBlock:^(CWebViewPlugin *obj, NSUInteger idx, BOOL *stop) {
-        if ([obj->webView isKindOfClass:[WKWebView class]]) {
-            WKWebView *webView = (WKWebView *)obj->webView;
-            webView.configuration.processPool = _sharedProcessPool;
-        }
-    }];
+    [CWebViewPlugin resetSharedProcessPool];
 }
 
-+ (const char *)getCookies:(const char *)url
+- (void)getCookies:(const char *)url
 {
-    // cf. https://stackoverflow.com/questions/33156567/getting-all-cookies-from-wkwebview/49744695#49744695
-    _sharedProcessPool = [[WKProcessPool alloc] init];
-    [_instances enumerateObjectsUsingBlock:^(CWebViewPlugin *obj, NSUInteger idx, BOOL *stop) {
-        if ([obj->webView isKindOfClass:[WKWebView class]]) {
-            WKWebView *webView = (WKWebView *)obj->webView;
-            webView.configuration.processPool = _sharedProcessPool;
+    NSOperatingSystemVersion version = { 9, 0, 0 };
+    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:version]) {
+        NSURL *nsurl = [NSURL URLWithString:[[NSString alloc] initWithUTF8String:url]];
+        WKHTTPCookieStore *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+        [cookieStore
+            getAllCookies:^(NSArray<NSHTTPCookie *> *array) {
+                NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+                formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+                [formatter setDateFormat:@"EEE, dd MMM yyyy HH:mm:ss zzz"];
+                NSMutableString *result = [NSMutableString string];
+                [array enumerateObjectsUsingBlock:^(NSHTTPCookie *cookie, NSUInteger idx, BOOL *stop) {
+                        if ([cookie.domain isEqualToString:nsurl.host]) {
+                            [result appendString:[NSString stringWithFormat:@"%@=%@", cookie.name, cookie.value]];
+                            if ([cookie.domain length] > 0) {
+                                [result appendString:[NSString stringWithFormat:@"; "]];
+                                [result appendString:[NSString stringWithFormat:@"Domain=%@", cookie.domain]];
+                            }
+                            if ([cookie.path length] > 0) {
+                                [result appendString:[NSString stringWithFormat:@"; "]];
+                                [result appendString:[NSString stringWithFormat:@"Path=%@", cookie.path]];
+                            }
+                            if (cookie.expiresDate != nil) {
+                                [result appendString:[NSString stringWithFormat:@"; "]];
+                                [result appendString:[NSString stringWithFormat:@"Expires=%@", [formatter stringFromDate:cookie.expiresDate]]];
+                            }
+                            [result appendString:[NSString stringWithFormat:@"; "]];
+                            [result appendString:[NSString stringWithFormat:@"Version=%zd", cookie.version]];
+                            [result appendString:[NSString stringWithFormat:@"\n"]];
+                        }
+                    }];
+                UnitySendMessage([gameObjectName UTF8String], "CallOnCookies", [result UTF8String]);
+            }];
+    } else {
+        [CWebViewPlugin resetSharedProcessPool];
+        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+        formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        [formatter setDateFormat:@"EEE, dd MMM yyyy HH:mm:ss zzz"];
+        NSMutableString *result = [NSMutableString string];
+        NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+        if (cookieStorage == nil) {
+            // cf. https://stackoverflow.com/questions/33876295/nshttpcookiestorage-sharedhttpcookiestorage-comes-up-empty-in-10-11
+            cookieStorage = [NSHTTPCookieStorage sharedCookieStorageForGroupContainerIdentifier:@"Cookies"];
         }
-    }];
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-    [formatter setDateFormat:@"EEE, dd MMM yyyy HH:mm:ss zzz"];
-    NSMutableString *result = [NSMutableString string];
-    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    if (cookieStorage == nil) {
-        // cf. https://stackoverflow.com/questions/33876295/nshttpcookiestorage-sharedhttpcookiestorage-comes-up-empty-in-10-11
-        cookieStorage = [NSHTTPCookieStorage sharedCookieStorageForGroupContainerIdentifier:@"Cookies"];
+        [[cookieStorage cookiesForURL:[NSURL URLWithString:[[NSString alloc] initWithUTF8String:url]]]
+            enumerateObjectsUsingBlock:^(NSHTTPCookie *cookie, NSUInteger idx, BOOL *stop) {
+                [result appendString:[NSString stringWithFormat:@"%@=%@", cookie.name, cookie.value]];
+                if ([cookie.domain length] > 0) {
+                    [result appendString:[NSString stringWithFormat:@"; "]];
+                    [result appendString:[NSString stringWithFormat:@"Domain=%@", cookie.domain]];
+                }
+                if ([cookie.path length] > 0) {
+                    [result appendString:[NSString stringWithFormat:@"; "]];
+                    [result appendString:[NSString stringWithFormat:@"Path=%@", cookie.path]];
+                }
+                if (cookie.expiresDate != nil) {
+                    [result appendString:[NSString stringWithFormat:@"; "]];
+                    [result appendString:[NSString stringWithFormat:@"Expires=%@", [formatter stringFromDate:cookie.expiresDate]]];
+                }
+                [result appendString:[NSString stringWithFormat:@"; "]];
+                [result appendString:[NSString stringWithFormat:@"Version=%zd", cookie.version]];
+                [result appendString:[NSString stringWithFormat:@"\n"]];
+            }];
+        UnitySendMessage([gameObjectName UTF8String], "CallOnCookies", [result UTF8String]);
     }
-    [[cookieStorage cookiesForURL:[NSURL URLWithString:[[NSString alloc] initWithUTF8String:url]]]
-        enumerateObjectsUsingBlock:^(NSHTTPCookie *cookie, NSUInteger idx, BOOL *stop) {
-            [result appendString:[NSString stringWithFormat:@"%@=%@", cookie.name, cookie.value]];
-            if ([cookie.domain length] > 0) {
-                [result appendString:[NSString stringWithFormat:@"; "]];
-                [result appendString:[NSString stringWithFormat:@"Domain=%@", cookie.domain]];
-            }
-            if ([cookie.path length] > 0) {
-                [result appendString:[NSString stringWithFormat:@"; "]];
-                [result appendString:[NSString stringWithFormat:@"Path=%@", cookie.path]];
-            }
-            if (cookie.expiresDate != nil) {
-                [result appendString:[NSString stringWithFormat:@"; "]];
-                [result appendString:[NSString stringWithFormat:@"Expires=%@", [formatter stringFromDate:cookie.expiresDate]]];
-            }
-            [result appendString:[NSString stringWithFormat:@"; "]];
-            [result appendString:[NSString stringWithFormat:@"Version=%zd", cookie.version]];
-            [result appendString:[NSString stringWithFormat:@"\n"]];
-        }];
-    const char *s = [result UTF8String];
-    char *r = (char *)malloc(strlen(s) + 1);
-    strcpy(r, s);
-    return r;
 }
 
 - (void)userContentController:(WKUserContentController *)userContentController
@@ -930,7 +962,7 @@ extern "C" {
     void _CWebViewPlugin_ClearCustomHeader(void *instance);
     void _CWebViewPlugin_ClearCookies();
     void _CWebViewPlugin_SaveCookies();
-    const char *_CWebViewPlugin_GetCookies(const char *url);
+    void _CWebViewPlugin_GetCookies(void *instance, const char *url);
     const char *_CWebViewPlugin_GetCustomHeaderValue(void *instance, const char *headerKey);
     void _CWebViewPlugin_SetBasicAuthInfo(void *instance, const char *userName, const char *password);
     void _CWebViewPlugin_ClearCache(void *instance, BOOL includeDiskFiles);
@@ -1128,9 +1160,10 @@ void _CWebViewPlugin_SaveCookies()
     [CWebViewPlugin saveCookies];
 }
 
-const char *_CWebViewPlugin_GetCookies(const char *url)
+void _CWebViewPlugin_GetCookies(void *instance, const char *url)
 {
-    return [CWebViewPlugin getCookies:url];
+    CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
+    [webViewPlugin getCookies:url];
 }
 
 const char *_CWebViewPlugin_GetCustomHeaderValue(void *instance, const char *headerKey)

--- a/sample/Assets/Scripts/SampleWebView.cs
+++ b/sample/Assets/Scripts/SampleWebView.cs
@@ -61,6 +61,10 @@ public class SampleWebView : MonoBehaviour
             {
                 Debug.Log(string.Format("CallOnHooked[{0}]", msg));
             },
+            cookies: (msg) =>
+            {
+                Debug.Log(string.Format("CallOnCookies[{0}]", msg));
+            },
             ld: (msg) =>
             {
                 Debug.Log(string.Format("CallOnLoaded[{0}]", msg));


### PR DESCRIPTION
The former implementation of GetCookies doesn't work well with recent iOS/OSX, so the code is changed to utilize WKHTTPCookieStore. As WKHTTPCookieStore.getAllCookies returns values through a completion handler, we newly add the `cookies:` callback to return those values.