### PR TITLE
[experimental] introduced saveDataURL for iOS.

### DIFF
--- a/sample/Assets/Scripts/SampleWebView.cs
+++ b/sample/Assets/Scripts/SampleWebView.cs
@@ -87,6 +87,11 @@ public class SampleWebView : MonoBehaviour
                       }
                     }
                   }
+                  if (window && window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.saveDataURL) {
+                    window.Unity.saveDataURL = function(fileName, dataURL) {
+                      window.webkit.messageHandlers.saveDataURL.postMessage(fileName + '\t' + dataURL);
+                    }
+                  }
                 ");
 #else
                 webViewObject.EvaluateJS(@"
@@ -105,6 +110,11 @@ public class SampleWebView : MonoBehaviour
                         iframe.parentNode.removeChild(iframe);
                         iframe = null;
                       }
+                    }
+                  }
+                  if (window && window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.saveDataURL) {
+                    window.Unity.saveDataURL = function(fileName, dataURL) {
+                      window.webkit.messageHandlers.saveDataURL.postMessage(fileName + '\t' + dataURL);
                     }
                   }
                 ");


### PR DESCRIPTION
cf. #875 
cf. #876
cf. https://github.com/gree/unity-webview/issues/874#issuecomment-1489357358

NOTE: Although saveDataURL() for Android saves a file under the common Downloads folder, this iOS version cannot do it. Instead, this version saves a file under the application's Downloads folder under Documents folder. To make Downloads visible for Files.app, UIFileSharingEnabled and LSSupportsOpeningDocumentsInPlace have to be set YES (cf. https://bignerdranch.com/blog/working-with-the-files-app-in-ios-11/ ).