### PR TITLE
modified to inject Unity.call definition by WKUserScript.

### DIFF
--- a/plugins/Mac/Sources/WebView.mm
+++ b/plugins/Mac/Sources/WebView.mm
@@ -146,10 +146,15 @@ static std::unordered_map<int, int> _nskey2cgkey{
     preferences.javaScriptEnabled = true;
     preferences.plugInsEnabled = true;
     [controller addScriptMessageHandler:self name:@"unityControl"];
+    NSString *str = @"\
+window.Unity = { \
+    call: function(msg) { \
+        window.webkit.messageHandlers.unityControl.postMessage(msg); \
+    } \
+}; \
+";
     if (!zoom) {
-        WKUserScript *script
-            = [[WKUserScript alloc]
-                      initWithSource:@"\
+        str = [str stringByAppendingString:@"\
 (function() { \
     var meta = document.querySelector('meta[name=viewport]'); \
     if (meta == null) { \
@@ -161,10 +166,11 @@ static std::unordered_map<int, int> _nskey2cgkey{
     head.appendChild(meta); \
 })(); \
 "
-                       injectionTime:WKUserScriptInjectionTimeAtDocumentEnd
-                    forMainFrameOnly:YES];
-        [controller addUserScript:script];
+          ];
     }
+    WKUserScript *script
+        = [[WKUserScript alloc] initWithSource:str injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES];
+    [controller addUserScript:script];
     configuration.userContentController = controller;
     configuration.processPool = _sharedProcessPool;
     // configuration.preferences = preferences;

--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -137,10 +137,18 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
         WKUserContentController *controller = [[WKUserContentController alloc] init];
         [controller addScriptMessageHandler:self name:@"unityControl"];
         [controller addScriptMessageHandler:self name:@"saveDataURL"];
+        NSString *str = @"\
+window.Unity = { \
+    call: function(msg) { \
+        window.webkit.messageHandlers.unityControl.postMessage(msg); \
+    }, \
+    saveDataURL: function(fileName, dataURL) { \
+        window.webkit.messageHandlers.saveDataURL.postMessage(fileName + '\t' + dataURL); \
+    } \
+}; \
+";
         if (!zoom) {
-            WKUserScript *script
-                = [[WKUserScript alloc]
-                      initWithSource:@"\
+          str = [str stringByAppendingString:@"\
 (function() { \
     var meta = document.querySelector('meta[name=viewport]'); \
     if (meta == null) { \
@@ -152,10 +160,11 @@ static NSMutableArray *_instances = [[NSMutableArray alloc] init];
     head.appendChild(meta); \
 })(); \
 "
-                       injectionTime:WKUserScriptInjectionTimeAtDocumentEnd
-                    forMainFrameOnly:YES];
-            [controller addUserScript:script];
+            ];
         }
+        WKUserScript *script
+            = [[WKUserScript alloc] initWithSource:str injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES];
+        [controller addUserScript:script];
         configuration.userContentController = controller;
         configuration.allowsInlineMediaPlayback = true;
         if (@available(iOS 10.0, *)) {


### PR DESCRIPTION
Historically Unity.call() for iOS is defined in `ld:` callback by invoking EvaluateJS(). It is however can be defined in the native plugin for WKWebView by utilizing WKUserScript.

cf. https://github.com/gree/unity-webview/pull/904#issuecomment-1493578108