### PR TITLE
fixed android keyboard detection.

### DIFF
--- a/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -561,24 +561,26 @@ public class CWebViewPlugin {
                     h = display.getHeight();
                 }
 
-                View rootView = activityRootView.getRootView();
-                int bottomPadding = 0;
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                    Point realSize = new Point();
-                    display.getRealSize(realSize); // this method was added at JELLY_BEAN_MR1
-                    int[] location = new int[2];
-                    rootView.getLocationOnScreen(location);
-                    bottomPadding = realSize.y - (location[1] + rootView.getHeight());
-                }
-                int heightDiff = rootView.getHeight() - (r.bottom - r.top);
-                String param = "" ;
-                if (heightDiff > 0 && (heightDiff + bottomPadding) > (h + bottomPadding) / 3) { // assume that this means that the keyboard is on
-                    param = "true";
-                } else {
-                    param = "false";
-                }
+                // View rootView = activityRootView.getRootView();
+                // int bottomPadding = 0;
+                // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                //     Point realSize = new Point();
+                //     display.getRealSize(realSize); // this method was added at JELLY_BEAN_MR1
+                //     int[] location = new int[2];
+                //     rootView.getLocationOnScreen(location);
+                //     bottomPadding = realSize.y - (location[1] + rootView.getHeight());
+                // }
+                // int heightDiff = rootView.getHeight() - (r.bottom - r.top);
+                // String param = "" ;
+                // if (heightDiff > 0 && (heightDiff + bottomPadding) > (h + bottomPadding) / 3) { // assume that this means that the keyboard is on
+                //     param = "true";
+                // } else {
+                //     param = "false";
+                // }
+
+                int heightDiff = activityRootView.getRootView().getHeight() - (r.bottom - r.top);
                 if (IsInitialized()) {
-                    MyUnitySendMessage(gameObject, "SetKeyboardVisible", param);
+                    MyUnitySendMessage(gameObject, "SetKeyboardVisible", Integer.toString(heightDiff));
                 }
             }
         };

--- a/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -816,24 +816,26 @@ public class CWebViewPlugin extends Fragment {
                     h = display.getHeight();
                 }
 
-                View rootView = activityRootView.getRootView();
-                int bottomPadding = 0;
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                    Point realSize = new Point();
-                    display.getRealSize(realSize); // this method was added at JELLY_BEAN_MR1
-                    int[] location = new int[2];
-                    rootView.getLocationOnScreen(location);
-                    bottomPadding = realSize.y - (location[1] + rootView.getHeight());
-                }
-                int heightDiff = rootView.getHeight() - (r.bottom - r.top);
-                String param = "" ;
-                if (heightDiff > 0 && (heightDiff + bottomPadding) > (h + bottomPadding) / 3) { // assume that this means that the keyboard is on
-                    param = "true";
-                } else {
-                    param = "false";
-                }
+                // View rootView = activityRootView.getRootView();
+                // int bottomPadding = 0;
+                // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                //     Point realSize = new Point();
+                //     display.getRealSize(realSize); // this method was added at JELLY_BEAN_MR1
+                //     int[] location = new int[2];
+                //     rootView.getLocationOnScreen(location);
+                //     bottomPadding = realSize.y - (location[1] + rootView.getHeight());
+                // }
+                // int heightDiff = rootView.getHeight() - (r.bottom - r.top);
+                // String param = "" ;
+                // if (heightDiff > 0 && (heightDiff + bottomPadding) > (h + bottomPadding) / 3) { // assume that this means that the keyboard is on
+                //     param = "" + heightDiff;
+                // } else {
+                //     param = "false";
+                // }
+
+                int heightDiff = activityRootView.getRootView().getHeight() - (r.bottom - r.top);
                 if (IsInitialized()) {
-                    MyUnitySendMessage(gameObject, "SetKeyboardVisible", param);
+                    MyUnitySendMessage(gameObject, "SetKeyboardVisible", Integer.toString(heightDiff));
                 }
             }
         };

--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -85,7 +85,7 @@ public class WebViewObject : MonoBehaviour
     AndroidJavaObject webView;
     
     bool mVisibility;
-    bool mIsKeyboardVisible;
+    int mKeyboardVisibleHeight;
     int mWindowVisibleDisplayFrameHeight;
     float mResumedTimestamp;
 #if UNITYWEBVIEW_ANDROID_ENABLE_NAVIGATOR_ONLINE
@@ -97,7 +97,7 @@ public class WebViewObject : MonoBehaviour
     {
         if (webView == null)
             return;
-        if (!paused && mIsKeyboardVisible)
+        if (!paused && mKeyboardVisibleHeight > 0)
         {
             webView.Call("SetVisibility", false);
             mResumedTimestamp = Time.realtimeSinceStartup;
@@ -169,16 +169,17 @@ public class WebViewObject : MonoBehaviour
     }
 
     /// Called from Java native plugin to set when the keyboard is opened
-    public void SetKeyboardVisible(string pIsVisible)
+    public void SetKeyboardVisible(string keyboardVisibleHeight)
     {
         if (BottomAdjustmentDisabled())
         {
             return;
         }
-        bool isKeyboardVisible0 = mIsKeyboardVisible;
-        mIsKeyboardVisible = (pIsVisible == "true");
-        if (mIsKeyboardVisible != isKeyboardVisible0 || mIsKeyboardVisible)
+        var keyboardVisibleHeight0 = mKeyboardVisibleHeight;
+        var keyboardVisibleHeight1 = Int32.Parse(keyboardVisibleHeight);
+        if (keyboardVisibleHeight0 != keyboardVisibleHeight1)
         {
+            mKeyboardVisibleHeight = keyboardVisibleHeight1;
             SetMargins(mMarginLeft, mMarginTop, mMarginRight, mMarginBottom, mMarginRelative);
         }
     }
@@ -302,7 +303,7 @@ public class WebViewObject : MonoBehaviour
         {
             return bottom;
         }
-        else if (!mIsKeyboardVisible)
+        else if (mKeyboardVisibleHeight <= 0)
         {
             return bottom;
         }
@@ -348,7 +349,7 @@ public class WebViewObject : MonoBehaviour
         get
         {
 #if !UNITY_EDITOR && UNITY_ANDROID
-            return mIsKeyboardVisible;
+            return mKeyboardVisibleHeight > 0;
 #elif !UNITY_EDITOR && UNITY_IPHONE
             return TouchScreenKeyboard.visible;
 #else


### PR DESCRIPTION
Determining whether the keyboard is visible is tricky and occasionally doesn't work. In this patch, we instead inform any global layout change to the unity side, as the logic adjusting margins doesn't directly depend on the keyboard visibility.

cf. #926 
cf. #723 