### PR TITLE
disabled android visibility control on pause/resume.

### DIFF
--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -97,11 +97,11 @@ public class WebViewObject : MonoBehaviour
     {
         if (webView == null)
             return;
-        if (!paused && mKeyboardVisibleHeight > 0)
-        {
-            webView.Call("SetVisibility", false);
-            mResumedTimestamp = Time.realtimeSinceStartup;
-        }
+        // if (!paused && mKeyboardVisibleHeight > 0)
+        // {
+        //     webView.Call("SetVisibility", false);
+        //     mResumedTimestamp = Time.realtimeSinceStartup;
+        // }
         webView.Call("OnApplicationPause", paused);
     }
 


### PR DESCRIPTION
cf. #944

Originally, a webview on Adnroid became temporarily invisible when the keyboard was visible and the app resumed. This logic was introduced in #300 to avoid some flapping display state. As in #928, though, we introduced a new detection of the keyboard more sensitive than the previous one, the logic is more frequently triggered and causes annoyance described in #944. The latter is more problematic so we disable the logic.