### PR TITLE
fixed to explicitly invoke requestLayout() for uniy issue 1361532.

### DIFF
--- a/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -37,6 +37,7 @@ import android.util.Base64;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.webkit.GeolocationPermissions.Callback;
@@ -754,6 +755,9 @@ public class CWebViewPlugin {
                 mWebView.setVisibility(View.VISIBLE);
                 layout.requestFocus();
                 mWebView.requestFocus();
+                if (layout != null && layout.getParent() != null && layout.getParent().getParent() != null) {
+                    ((ViewGroup)layout.getParent().getParent()).requestLayout();
+                }
             } else {
                 mWebView.setVisibility(View.GONE);
             }

--- a/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -45,6 +45,7 @@ import android.util.Pair;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.webkit.GeolocationPermissions.Callback;
@@ -1087,6 +1088,9 @@ public class CWebViewPlugin extends Fragment {
                 mWebView.setVisibility(View.VISIBLE);
                 layout.requestFocus();
                 mWebView.requestFocus();
+                if (layout != null && layout.getParent() != null && layout.getParent().getParent() != null) {
+                    ((ViewGroup)layout.getParent().getParent()).requestLayout();
+                }
             } else {
                 mWebView.setVisibility(View.GONE);
             }


### PR DESCRIPTION
cf. https://github.com/gree/unity-webview/issues/979#issuecomment-1740445457
cf. https://issuetracker.unity3d.com/issues/android-unity-app-background-gets-black-when-dialog-window-remains-open-after-re-entering-the-app
