### PR TITLE
Allow 'about:srcdoc' URLs in WKWebView to support the iframe srcdoc attribute.

### DIFF
--- a/dist/package/Assets/Plugins/iOS/WebView.mm
+++ b/dist/package/Assets/Plugins/iOS/WebView.mm
@@ -544,6 +544,7 @@ window.Unity = { \
         decisionHandler(WKNavigationActionPolicyCancel);
         return;
     } else if (![url hasPrefix:@"about:blank"]  // for loadHTML(), cf. #365
+               && ![url hasPrefix:@"about:srcdoc"] // for iframe srcdoc attribute
                && ![url hasPrefix:@"file:"]
                && ![url hasPrefix:@"http:"]
                && ![url hasPrefix:@"https:"]) {

--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -544,6 +544,7 @@ window.Unity = { \
         decisionHandler(WKNavigationActionPolicyCancel);
         return;
     } else if (![url hasPrefix:@"about:blank"]  // for loadHTML(), cf. #365
+               && ![url hasPrefix:@"about:srcdoc"] // for iframe srcdoc attribute
                && ![url hasPrefix:@"file:"]
                && ![url hasPrefix:@"http:"]
                && ![url hasPrefix:@"https:"]) {


### PR DESCRIPTION
## Summary
When trying to display a document using the srcdoc attribute of an iframe in WKWebView, a request is sent to `decidePolicyForNavigationAction` with a URL of `about:srcdoc`, so allow this in order to display it This was necessary to allow the request to be displayed.

## cf 
- https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/1272#issuecomment-800908974
- https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2960