### PR TITLE
fixed to set mWebView = null in ui thread (mWebView should always be modifed in UI thread).

### DIFF
--- a/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -591,12 +591,12 @@ public class CWebViewPlugin {
 
     public void Destroy() {
         final Activity a = UnityPlayer.currentActivity;
-        final WebView webView = mWebView;
-        mWebView = null;
         if (CWebViewPlugin.isDestroyed(a)) {
             return;
         }
         a.runOnUiThread(new Runnable() {public void run() {
+            final WebView webView = mWebView;
+            mWebView = null;
             if (webView == null) {
                 return;
             }

--- a/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -908,13 +908,13 @@ public class CWebViewPlugin extends Fragment {
     public void Destroy() {
         final Activity a = UnityPlayer.currentActivity;
         final CWebViewPlugin self = this;
-        final WebView webView = mWebView;
-        mWebView = null;
         mMessages.clear();
         if (CWebViewPlugin.isDestroyed(a)) {
             return;
         }
         a.runOnUiThread(new Runnable() {public void run() {
+            final WebView webView = mWebView;
+            mWebView = null;
             if (webView == null) {
                 return;
             }


### PR DESCRIPTION
cf. #994 

`mWebView = null` in Unity's thread was introduced in #784. This however may make `mWebView` `null` suddenly in the middle of any Runnable's `run()` method running in the UI thread. This pull request fixes this issue by performing `mWebView = null` in the UI thread.

It actually reverts #784 , but is okay because #794 should reduce the original issue in #783.