### PR TITLE
fix "gamma correction" issue on linear space

### DIFF
--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -1524,7 +1524,8 @@ public class WebViewObject : MonoBehaviour
                 var w = _CWebViewPlugin_BitmapWidth(webView);
                 var h = _CWebViewPlugin_BitmapHeight(webView);
                 if (texture == null || texture.width != w || texture.height != h) {
-                    texture = new Texture2D(w, h, TextureFormat.RGBA32, false, true);
+                    bool isLinearSpace = QualitySettings.activeColorSpace == ColorSpace.Linear;
+                    texture = new Texture2D(w, h, TextureFormat.RGBA32, false, !isLinearSpace);
                     texture.filterMode = FilterMode.Bilinear;
                     texture.wrapMode = TextureWrapMode.Clamp;
                     textureDataBuffer = new byte[w * h * 4];
@@ -1595,7 +1596,7 @@ public class WebViewObject : MonoBehaviour
                         new Vector3(0, Screen.height, 0),
                         Quaternion.identity,
                         new Vector3(1, -1, 1));
-                GUI.DrawTexture(rect, texture);
+                Graphics.DrawTexture(rect, texture);
                 GUI.matrix = m;
             }
             break;


### PR DESCRIPTION
## Problem

As title, I found that the webview in OSX/Editor encounter a problem that the website will be rendered brighter than it should be as following:
 ![linear_before](https://github.com/gree/unity-webview/assets/14183364/b385f30c-b096-42eb-915b-be624f5efd89)

similar issue: https://github.com/gree/unity-webview/issues/691

## Reproduction
Start the sample project and set it to "linear space"

## Reason

The reason is that Unity didn't implement the IMGUI draw texture correctly. 😅 
If we peak at the IMGUI's render pass, we found out the shader it used "Internal-GUITextureClip.shader":
![image](https://github.com/gree/unity-webview/assets/14183364/6e035134-c648-4667-a8d1-ae679cb5df92)
And which DID [support the gamma correction](https://github.com/TwoTailsGames/Unity-Built-in-Shaders/blob/master/DefaultResourcesExtra/Internal-GUITextureClip.shader#L56).
However, the runtime IMGUI didn't raise the flag for linear space, so we cannot do anything for that.
(BTW: unity remember the handle this in [Editor GUI ](https://github.com/Unity-Technologies/UnityCsReference/blob/6c8a95ff127619e73519662fa497e242b898f9af/Editor/Mono/EditorGUIUtility.cs#L82))


## Solution

The fix focus on 2 parts, Texture declaration and Texture Drawing.

Texture part is just remember to set the linear argument, which can support linear space properly.
Then the render part, I choose to use Graphics.DrawTexture directly, it because the [GUI.DrawTexture](https://github.com/Unity-Technologies/UnityCsReference/blob/6c8a95ff127619e73519662fa497e242b898f9af/Modules/IMGUI/GUI.cs#L251) is also calling to the Graphics.Internal_DrawTexture.
And the result is like:
![linear_after](https://github.com/gree/unity-webview/assets/14183364/9d3be18a-71ad-4069-ad6c-8f566506cc1b)


## ct
https://docs.unity3d.com/ScriptReference/Texture2D-ctor.html
https://issuetracker.unity3d.com/issues/gui-dot-drawtexture-is-too-bright-slash-washed-out-when-color-space-is-set-to-linear-mode



