### PR TITLE
fixed to enclose bg-related code with "#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX".

### DIFF
--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -897,10 +897,12 @@ public class WebViewObject : MonoBehaviour
 
     public void SetVisibility(bool v)
     {
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         if (bg != null)
         {
             bg.gameObject.active = v;
         }
+#endif
         if (GetVisibility() && !v)
         {
             EvaluateJS("if (document && document.activeElement) document.activeElement.blur();");


### PR DESCRIPTION
cf. https://github.com/gree/unity-webview/commit/e9b323c77329a02a78246ce78d984195dcb77cfb#commitcomment-140337237