### PR TITLE
fixed AdjustBottomMargin() for "windowed" mode with "status bar" and "render outside safe area".

### DIFF
--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -379,11 +379,13 @@ public class WebViewObject : MonoBehaviour
             using (var view = player.Call<AndroidJavaObject>("getView"))
             using (var rect = new AndroidJavaObject("android.graphics.Rect"))
             {
-                view.Call("getDrawingRect", rect);
-                int h0 = rect.Call<int>("height");
-                view.Call("getWindowVisibleDisplayFrame", rect);
-                int h1 = rect.Call<int>("height");
-                keyboardHeight = h0 - h1;
+                if (view.Call<bool>("getGlobalVisibleRect", rect))
+                {
+                    int h0 = rect.Get<int>("bottom");
+                    view.Call("getWindowVisibleDisplayFrame", rect);
+                    int h1 = rect.Get<int>("bottom");
+                    keyboardHeight = h0 - h1;
+                }
             }
             return (bottom > keyboardHeight) ? bottom : keyboardHeight;
         }


### PR DESCRIPTION
cf. #1075 

This patch replaces getDrawingRect with getGlobalVisibleRect so that "bottom" values can be compared. This works for any combination of "status bar" on/off and "render outside safe area" on/off.