### PR TITLE
add accessibility workaround for Unity 6

### DIFF
--- a/dist/package/Assets/Plugins/iOS/WebView.mm
+++ b/dist/package/Assets/Plugins/iOS/WebView.mm
@@ -266,7 +266,10 @@ window.Unity = { \
     [webView addObserver:self forKeyPath: @"loading" options: NSKeyValueObservingOptionNew context:nil];
 
     [view addSubview:webView];
-
+    
+    //set webview for Unity 6 accessibility hierarchy
+    view.accessibilityElements = @[webView]; // workaround
+    
     return self;
 }
 
@@ -284,6 +287,13 @@ window.Unity = { \
         [webView0 stopLoading];
         [webView0 removeFromSuperview];
         [webView0 removeObserver:self forKeyPath:@"loading"];
+        
+        //remove the WebViewObject from Unity hierarchy tree
+        UIView *view = UnityGetGLViewController().view;
+        NSMutableArray<UIAccessibilityElement *> *accessibilityElements = view.accessibilityElements ?
+        [view.accessibilityElements mutableCopy] : [NSMutableArray array];
+        [accessibilityElements removeObject: (UIAccessibilityElement *)webView];
+        view.accessibilityElements = accessibilityElements;
     }
     basicAuthPassword = nil;
     basicAuthUserName = nil;

--- a/dist/package/Assets/Plugins/iOS/WebView.mm
+++ b/dist/package/Assets/Plugins/iOS/WebView.mm
@@ -266,9 +266,12 @@ window.Unity = { \
     [webView addObserver:self forKeyPath: @"loading" options: NSKeyValueObservingOptionNew context:nil];
 
     [view addSubview:webView];
-    
+
     //set webview for Unity 6 accessibility hierarchy
-    view.accessibilityElements = @[webView]; // workaround
+    NSMutableArray<UIAccessibilityElement *> *accessibilityElements
+        = view.accessibilityElements ? [view.accessibilityElements mutableCopy] : [NSMutableArray array];
+    [accessibilityElements addObject:(UIAccessibilityElement *)webView];
+    view.accessibilityElements = accessibilityElements;
     
     return self;
 }
@@ -290,9 +293,9 @@ window.Unity = { \
         
         //remove the WebViewObject from Unity hierarchy tree
         UIView *view = UnityGetGLViewController().view;
-        NSMutableArray<UIAccessibilityElement *> *accessibilityElements = view.accessibilityElements ?
-        [view.accessibilityElements mutableCopy] : [NSMutableArray array];
-        [accessibilityElements removeObject: (UIAccessibilityElement *)webView];
+        NSMutableArray<UIAccessibilityElement *> *accessibilityElements
+            = view.accessibilityElements ? [view.accessibilityElements mutableCopy] : [NSMutableArray array];
+        [accessibilityElements removeObject: (UIAccessibilityElement *)webView0];
         view.accessibilityElements = accessibilityElements;
     }
     basicAuthPassword = nil;

--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -267,6 +267,9 @@ window.Unity = { \
 
     [view addSubview:webView];
 
+    //set webview for Unity 6 accessibility hierarchy
+    view.accessibilityElements = @[webView]; // workaround
+    
     return self;
 }
 
@@ -284,6 +287,13 @@ window.Unity = { \
         [webView0 stopLoading];
         [webView0 removeFromSuperview];
         [webView0 removeObserver:self forKeyPath:@"loading"];
+        
+        //remove the WebViewObject from Unity hierarchy tree
+        UIView *view = UnityGetGLViewController().view;
+        NSMutableArray<UIAccessibilityElement *> *accessibilityElements = view.accessibilityElements ?
+        [view.accessibilityElements mutableCopy] : [NSMutableArray array];
+        [accessibilityElements removeObject: (UIAccessibilityElement *)webView];
+        view.accessibilityElements = accessibilityElements;
     }
     basicAuthPassword = nil;
     basicAuthUserName = nil;

--- a/plugins/iOS/WebView.mm
+++ b/plugins/iOS/WebView.mm
@@ -268,7 +268,10 @@ window.Unity = { \
     [view addSubview:webView];
 
     //set webview for Unity 6 accessibility hierarchy
-    view.accessibilityElements = @[webView]; // workaround
+    NSMutableArray<UIAccessibilityElement *> *accessibilityElements
+        = view.accessibilityElements ? [view.accessibilityElements mutableCopy] : [NSMutableArray array];
+    [accessibilityElements addObject:(UIAccessibilityElement *)webView];
+    view.accessibilityElements = accessibilityElements;
     
     return self;
 }
@@ -290,9 +293,9 @@ window.Unity = { \
         
         //remove the WebViewObject from Unity hierarchy tree
         UIView *view = UnityGetGLViewController().view;
-        NSMutableArray<UIAccessibilityElement *> *accessibilityElements = view.accessibilityElements ?
-        [view.accessibilityElements mutableCopy] : [NSMutableArray array];
-        [accessibilityElements removeObject: (UIAccessibilityElement *)webView];
+        NSMutableArray<UIAccessibilityElement *> *accessibilityElements
+            = view.accessibilityElements ? [view.accessibilityElements mutableCopy] : [NSMutableArray array];
+        [accessibilityElements removeObject: (UIAccessibilityElement *)webView0];
         view.accessibilityElements = accessibilityElements;
     }
     basicAuthPassword = nil;


### PR DESCRIPTION
Hi, @KojiNakamaru 

Unity 6 introduces an [Accessibility API for mobile devices that uses the Operation System's API](https://unity.com/blog/engine-platform/mobile-screen-reader-support-in-unity) to expose accessible elements so that users can navigate Unity Apps natively and developers can integrate it without the need to build complex functionality..  

Currently, Webview is not "visible" to Voiceover for iOS. @bianca-stana suggested a workaround that connects the webview to the hierarchy tree. See discussion [here](https://discussions.unity.com/t/webview-objects-with-unity-6-accessibility-api/1596477/5). 

This is obviously a hack but it would be great if we could fully integrate Unity-Webview with accessibility functionality!