### PR TITLE
introduced ClearCookie.

### DIFF
--- a/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview-nofragment/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -1040,6 +1040,30 @@ public class CWebViewPlugin {
         }});
     }
 
+    public void ClearCookie(String url, String name)
+    {
+        try {
+            URL u = new URL(url);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                CookieManager cookieManager = CookieManager.getInstance();
+                String cookieString = name + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=" + u.getPath();
+                cookieManager.setCookie(url, cookieString);
+                cookieManager.flush();
+            } else {
+                final Activity a = UnityPlayer.currentActivity;
+                if (CWebViewPlugin.isDestroyed(a)) {
+                    return;
+                }
+                CookieSyncManager cookieSyncManager = CookieSyncManager.createInstance(a);
+                cookieSyncManager.startSync();
+                CookieManager cookieManager = CookieManager.getInstance();
+                String cookieString = name + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC; domain=" + u.getHost() + "; path=" + u.getPath();
+                cookieManager.setCookie(url, cookieString);
+            }
+        } catch (Exception e) {
+        }
+    }
+
     public void ClearCookies()
     {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)

--- a/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
+++ b/plugins/Android/webview/src/main/java/net/gree/unitywebview/CWebViewPlugin.java
@@ -1397,6 +1397,30 @@ public class CWebViewPlugin extends Fragment {
         }});
     }
 
+    public void ClearCookie(String url, String name)
+    {
+        try {
+            URL u = new URL(url);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                CookieManager cookieManager = CookieManager.getInstance();
+                String cookieString = name + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=" + u.getPath();
+                cookieManager.setCookie(url, cookieString);
+                cookieManager.flush();
+            } else {
+                final Activity a = UnityPlayer.currentActivity;
+                if (CWebViewPlugin.isDestroyed(a)) {
+                    return;
+                }
+                CookieSyncManager cookieSyncManager = CookieSyncManager.createInstance(a);
+                cookieSyncManager.startSync();
+                CookieManager cookieManager = CookieManager.getInstance();
+                String cookieString = name + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC; domain=" + u.getHost() + "; path=" + u.getPath();
+                cookieManager.setCookie(url, cookieString);
+            }
+        } catch (Exception e) {
+        }
+    }
+
     public void ClearCookies()
     {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)

--- a/plugins/Mac/Sources/WebView.mm
+++ b/plugins/Mac/Sources/WebView.mm
@@ -310,6 +310,42 @@ window.Unity = { \
     }];
 }
 
++ (void)clearCookie:(const char *)name of:(const char *)url
+{
+    NSURL *nsurl = [NSURL URLWithString:[[NSString alloc] initWithUTF8String:url]];
+    if (nsurl == nil) {
+        return;
+    }
+    NSString *nsname = [NSString stringWithUTF8String:name];
+    if (@available(macOS 10.11, *)) {
+        WKHTTPCookieStore *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+        [cookieStore
+            getAllCookies:^(NSArray<NSHTTPCookie *> *array) {
+                [array
+                    enumerateObjectsUsingBlock:^(NSHTTPCookie *cookie, NSUInteger idx, BOOL *stop) {
+                        if ([cookie.name isEqualToString:nsname]
+                            && [cookie.domain isEqualToString:nsurl.host]
+                            && [cookie.path isEqualToString:nsurl.path]) {
+                            [cookieStore deleteCookie:cookie completionHandler:^{}];
+                        }
+                    }];
+            }];
+    } else {
+        NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+        if (cookieStorage == nil) {
+            // cf. https://stackoverflow.com/questions/33876295/nshttpcookiestorage-sharedhttpcookiestorage-comes-up-empty-in-10-11
+            cookieStorage = [NSHTTPCookieStorage sharedCookieStorageForGroupContainerIdentifier:@"Cookies"];
+        }
+        [[cookieStorage cookies] enumerateObjectsUsingBlock:^(NSHTTPCookie *cookie, NSUInteger idx, BOOL *stop) {
+            if ([cookie.name isEqualToString:nsname]
+                && [cookie.domain isEqualToString:nsurl.host]
+                && [cookie.path isEqualToString:nsurl.path]) {
+                [cookieStorage deleteCookie:cookie];
+            }
+        }];
+    }
+}
+
 + (void)clearCookies
 {
     [CWebViewPlugin resetSharedProcessPool];
@@ -1007,6 +1043,7 @@ extern "C" {
     void _CWebViewPlugin_RemoveCustomHeader(void *instance, const char *headerKey);
     void _CWebViewPlugin_ClearCustomHeader(void *instance);
     const char *_CWebViewPlugin_GetCustomHeaderValue(void *instance, const char *headerKey);
+    void _CWebViewPlugin_ClearCookie(const char *url, const char *name);
     void _CWebViewPlugin_ClearCookies();
     void _CWebViewPlugin_SaveCookies();
     void _CWebViewPlugin_GetCookies(void *instance, const char *url);
@@ -1183,6 +1220,11 @@ void _CWebViewPlugin_ClearCustomHeader(void *instance)
 {
     CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
     [webViewPlugin clearCustomRequestHeader];
+}
+
+void _CWebViewPlugin_ClearCookie(const char *url, const char *name)
+{
+    [CWebViewPlugin clearCookie:name of:url];
 }
 
 void _CWebViewPlugin_ClearCookies()

--- a/plugins/WebViewObject.cs
+++ b/plugins/WebViewObject.cs
@@ -502,6 +502,8 @@ public class WebViewObject : MonoBehaviour
     [DllImport("WebView")]
     private static extern void _CWebViewPlugin_ClearCustomHeader(IntPtr instance);
     [DllImport("WebView")]
+    private static extern void _CWebViewPlugin_ClearCookie(string url, string name);
+    [DllImport("WebView")]
     private static extern void _CWebViewPlugin_ClearCookies();
     [DllImport("WebView")]
     private static extern void _CWebViewPlugin_SaveCookies();
@@ -576,6 +578,8 @@ public class WebViewObject : MonoBehaviour
     private static extern void _CWebViewPlugin_RemoveCustomHeader(IntPtr instance, string headerKey);
     [DllImport("__Internal")]
     private static extern void _CWebViewPlugin_ClearCustomHeader(IntPtr instance);
+    [DllImport("__Internal")]
+    private static extern void _CWebViewPlugin_ClearCookie(string url, string name);
     [DllImport("__Internal")]
     private static extern void _CWebViewPlugin_ClearCookies();
     [DllImport("__Internal")]
@@ -1420,6 +1424,23 @@ public class WebViewObject : MonoBehaviour
         if (webView == null)
             return;
         webView.Call("ClearCustomHeader");
+#endif
+    }
+
+    public void ClearCookie(string url, string name)
+    {
+#if UNITY_WEBPLAYER || UNITY_WEBGL
+        //TODO: UNSUPPORTED
+#elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || UNITY_EDITOR_LINUX || UNITY_SERVER
+        //TODO: UNSUPPORTED
+#elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IPHONE
+        if (webView == IntPtr.Zero)
+            return;
+        _CWebViewPlugin_ClearCookie(url, name);
+#elif UNITY_ANDROID && !UNITY_EDITOR
+        if (webView == null)
+            return;
+        webView.Call("ClearCookie", url, name);
 #endif
     }
 

--- a/plugins/iOS/WebViewWithUIWebView.mm
+++ b/plugins/iOS/WebViewWithUIWebView.mm
@@ -372,6 +372,42 @@ window.Unity = { \
     }];
 }
 
++ (void)clearCookie:(const char *)name of:(const char *)url
+{
+    NSURL *nsurl = [NSURL URLWithString:[[NSString alloc] initWithUTF8String:url]];
+    if (nsurl == nil) {
+        return;
+    }
+    NSString *nsname = [NSString stringWithUTF8String:name];
+    if (@available(iOS 9.0, *)) {
+        WKHTTPCookieStore *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+        [cookieStore
+            getAllCookies:^(NSArray<NSHTTPCookie *> *array) {
+                [array
+                    enumerateObjectsUsingBlock:^(NSHTTPCookie *cookie, NSUInteger idx, BOOL *stop) {
+                        if ([cookie.name isEqualToString:nsname]
+                            && [cookie.domain isEqualToString:nsurl.host]
+                            && [cookie.path isEqualToString:nsurl.path]) {
+                            [cookieStore deleteCookie:cookie completionHandler:^{}];
+                        }
+                    }];
+            }];
+    } else {
+        NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+        if (cookieStorage == nil) {
+            // cf. https://stackoverflow.com/questions/33876295/nshttpcookiestorage-sharedhttpcookiestorage-comes-up-empty-in-10-11
+            cookieStorage = [NSHTTPCookieStorage sharedCookieStorageForGroupContainerIdentifier:@"Cookies"];
+        }
+        [[cookieStorage cookies] enumerateObjectsUsingBlock:^(NSHTTPCookie *cookie, NSUInteger idx, BOOL *stop) {
+            if ([cookie.name isEqualToString:nsname]
+                && [cookie.domain isEqualToString:nsurl.host]
+                && [cookie.path isEqualToString:nsurl.path]) {
+                [cookieStorage deleteCookie:cookie];
+            }
+        }];
+    }
+}
+
 + (void)clearCookies
 {
     [CWebViewPlugin resetSharedProcessPool];
@@ -1092,6 +1128,7 @@ extern "C" {
     void _CWebViewPlugin_AddCustomHeader(void *instance, const char *headerKey, const char *headerValue);
     void _CWebViewPlugin_RemoveCustomHeader(void *instance, const char *headerKey);
     void _CWebViewPlugin_ClearCustomHeader(void *instance);
+    void _CWebViewPlugin_ClearCookie(const char *url, const char *name);
     void _CWebViewPlugin_ClearCookies();
     void _CWebViewPlugin_SaveCookies();
     void _CWebViewPlugin_GetCookies(void *instance, const char *url);
@@ -1297,6 +1334,11 @@ void _CWebViewPlugin_ClearCustomHeader(void *instance)
         return;
     CWebViewPlugin *webViewPlugin = (__bridge CWebViewPlugin *)instance;
     [webViewPlugin clearCustomRequestHeader];
+}
+
+void _CWebViewPlugin_ClearCookie(const char *url, const char *name)
+{
+    [CWebViewPlugin clearCookie:name of:url];
 }
 
 void _CWebViewPlugin_ClearCookies()


### PR DESCRIPTION
cf. #1171 

NOTE: ClearCookie() might not work before any page is loaded. This issue can be reduced by loading `about:blank` before loading the target page.