### PR TITLE
Implement navigation and capture fixes for Windows WebView2 plugin

### DIFF
--- a/plugins/Windows/PlanDocument/windows_webview2_navigation_capture_fix_plan_cht.md
+++ b/plugins/Windows/PlanDocument/windows_webview2_navigation_capture_fix_plan_cht.md
@@ -1,0 +1,73 @@
+---
+name: Windows WebView2 導覽與擷取管線修正
+overview: 快速切換網址或載入繁重頁面時, Unity 可能仍顯示舊貼圖、導覽未生效, 或僅有 CallOnStarted 而無 CallOnLoaded. Windows 外掛改為在新導覽前先停止進行中的導覽、將 Navigate 延後到下一輪訊息迴圈、在載入或導覽完成時解除 CapturePreview 鎖定, 並與 Destroy 時先 Stop 的行為一致.
+todos: []
+isProject: false
+---
+
+## Windows WebView2: 導覽與離屏擷取修正
+
+### 問題摘要
+
+- **換網址後畫面仍是舊頁**: Windows 上畫面來自 `CapturePreview` 的點陣圖. `_CWebViewPlugin_Update` 僅在 `captureInProgress` 為 false 時才 Post `WM_WEBVIEW_CAPTURE`. 若上一張 `CapturePreview` 的回呼延遲或未執行, 旗標可能一直為 true, Unity 仍畫舊幀, 即使新文件已觸發 `CallOnLoaded`.
+- **快速連續換網址**: 在同一個訊息處理裡對 `Stop()` 後立刻 `Navigate` 可能與 WebView2 競態: `Stop()` 未必同步完成, 下一個 `Navigate` 可能被忽略或看起來卡住.
+- **對同一 URL 重複 LoadURL**: 若已 `CallOnStarted` 卻始終沒有成功的 `CallOnLoaded`, 僅重送相同 URL 可能無法恢復; C# 端可能仍需 `about:blank` 再導向等作法.
+- **載入中 Destroy**: 釋放 COM 前先停止導覽 (其他計畫已述) 可降低繁重頁面崩潰; 一般載入路徑也採用先 `Stop` 再導向, 與該策略一致.
+
+**檔案**: `plugins/Windows/WebViewPlugin.cpp`
+
+---
+
+### 1. `NavigationCompleted`: 清除 `captureInProgress`
+
+**位置**: `add_NavigationCompleted` 回呼開頭.
+
+**原因**: Unity 端 `WebViewObject.Update` 以 `captureInProgress.exchange(true)` 決定是否 Post 擷取. 若旗標未清除, 不會再排 `CapturePreview`, 貼圖不會更新.
+
+**作法**: 在 `NavigationCompleted` 回呼一開始設 `inst->captureInProgress = false`, 讓每次導覽結束後下一幀的 `Update` 能再排新的擷取.
+
+**備註**: 理論上可能與尚未完成的舊 `CapturePreview` 重疊; 實務上可解決常見的貼圖卡死. 若需更嚴謹可再加世代序號忽略過期回呼.
+
+---
+
+### 2. `WM_WEBVIEW_LOAD_URL`: `Stop()`、清除擷取旗標、延遲 `Navigate`
+
+**位置**: `WndProc` 的 `case WM_WEBVIEW_LOAD_URL`.
+
+**原因**:
+
+- 新導覽前先取消上一段, 與 `WM_WEBVIEW_DESTROY` 的作法一致.
+- 明確換網址時清除 `captureInProgress`, 避免從繁重或異常頁面切走時擷取鎖卡住.
+- 以 **下一輪訊息迴圈** 執行 `Navigate` (`PostMessage` 且 `wParam == 1`), 讓 `Stop()` 有機會生效; 同一則訊息內立刻 `Navigate` 在忙碌頁面上可能被丟棄.
+
+**作法**:
+
+- `wParam == 0` (由 `_CWebViewPlugin_LoadURL` 送出): `Stop()`, `captureInProgress = false`, 再 `PostMessage(hwnd, WM_WEBVIEW_LOAD_URL, 1, (LPARAM)url)`, 此時不可 `delete[] url`.
+- `wParam == 1`: `Navigate(url)` 後 `delete[] url`.
+- 若 `inst` 或 `webview` 無效則 `delete[] url` 並 return, 避免洩漏.
+
+---
+
+### 3. `WM_WEBVIEW_LOAD_HTML`: `NavigateToString` 前先 `Stop()` 並清除 `captureInProgress`
+
+**位置**: `case WM_WEBVIEW_LOAD_HTML`.
+
+**原因**: 與 HTTP 載入相同, 先結束進行中導覽並解鎖擷取管線, 再換文件內容.
+
+**作法**: 在 `NavigateToString` 前呼叫 `Stop()` 並設 `captureInProgress = false`.
+
+---
+
+### 4. 與 Unity / C# 的關係 (本 C++ 檔案外)
+
+- Windows 上 `WebViewObject` 預設 `bitmapRefreshCycle = 10` 建議維持: iOS 等路徑較接近原生顯示, Windows 依賴 `CapturePreview` 離屏貼圖, 更新越頻繁越吃效能. 若仍覺畫面不夠順, 可視裝置與場景**自行調低**此值 (例如 `3`) 以換取較常重繪, 與上述原生修正可一併評估.
+- C# 可另做導覽監看 (逾時、`about:blank`、cache-busting) 處理僅有 `CallOnStarted` 而無 `CallOnLoaded` 的情況.
+
+---
+
+### 建議驗證
+
+1. Windows Editor 或 Standalone: 於多個 HTTPS 站之間快速切換 (含首頁較重的站).
+2. 確認最後一次要求的網址與 `CallOnLoaded`、畫面內容一致.
+3. 在慢載頁面完成前切到另一站, 確認不需多次手動重試即可看到新頁.
+4. 迴歸: 載入中 Destroy WebView, 確認無新崩潰 (若已套用其他 Destroy / C# `OnDestroy` 修正則一併驗證).

--- a/plugins/Windows/PlanDocument/windows_webview2_navigation_capture_fix_plan_en.md
+++ b/plugins/Windows/PlanDocument/windows_webview2_navigation_capture_fix_plan_en.md
@@ -1,0 +1,75 @@
+---
+name: Windows WebView2 navigation and capture pipeline fixes
+overview: When switching URLs quickly or loading heavy pages, Unity could show stale textures, miss navigations, or get stuck with CallOnStarted without CallOnLoaded. The Windows plugin now stops in-flight navigation before starting a new one, defers Navigate to the next message pump, clears the CapturePreview gate when loading or when navigation completes, and aligns Destroy-time behavior with safer teardown.
+todos: []
+isProject: false
+---
+
+## Windows WebView2: navigation and offscreen capture fixes
+
+### Problem summary
+
+- **Stale texture after URL change**: On Windows, the visible page is a bitmap from `CapturePreview`. `_CWebViewPlugin_Update` only posts `WM_WEBVIEW_CAPTURE` when `captureInProgress` is false. If a previous `CapturePreview` completion is delayed or never runs, `captureInProgress` can stay true, so Unity keeps rendering the old frame even though `CallOnLoaded` already fired for the new document.
+- **Rapid URL switching**: Calling `Navigate` immediately after `Stop()` in the same message handler can race WebView2: `Stop()` is not always synchronous, so the next `Navigate` may be ignored or the view may appear stuck until the user retries.
+- **Repeated `LoadURL` to the same URL**: If navigation started (`CallOnStarted`) but never completed successfully (`CallOnLoaded`), resending the same URL from managed code may not recover; application-level workarounds (e.g. `about:blank` then target URL) may still be needed in C#.
+- **Destroy while loading**: Stopping navigation before releasing COM (already documented in related plans) reduces crashes on heavy pages; this change keeps `Stop()` before `Navigate` consistent with that idea for normal loads.
+
+**File**: `plugins/Windows/WebViewPlugin.cpp`
+
+---
+
+### 1. `NavigationCompleted`: clear `captureInProgress`
+
+**Location**: `add_NavigationCompleted` handler (early in the callback).
+
+**Reason**: Unity’s managed `WebViewObject.Update` uses `captureInProgress.exchange(true)` before posting a capture. If the flag never clears, no new `CapturePreview` is scheduled and the texture never updates for the new page.
+
+**Change**: At the beginning of the `NavigationCompleted` callback, set `inst->captureInProgress = false` so the next Unity `Update` can enqueue a fresh capture after each navigation finishes (success or failure path still advances the pipeline).
+
+**Note**: There is a theoretical race if two `CapturePreview` operations overlap; in practice this unblocks the common “stuck bitmap” case. If needed later, a generation counter could ignore stale completion callbacks.
+
+---
+
+### 2. `WM_WEBVIEW_LOAD_URL`: `Stop()`, clear capture flag, defer `Navigate`
+
+**Location**: `case WM_WEBVIEW_LOAD_URL` in `WndProc`.
+
+**Reason**:
+
+- Cancel the previous navigation before starting another, matching the pattern used in `WM_WEBVIEW_DESTROY`.
+- Clearing `captureInProgress` when explicitly loading a new URL avoids a stuck capture lock when switching away from a heavy or hung page.
+- Posting `Navigate` on the **next** message pump (`PostMessage` with `wParam == 1`) gives `Stop()` time to take effect; immediate `Navigate` in the same handler could be dropped on busy pages.
+
+**Change**:
+
+- `wParam == 0` (used by `_CWebViewPlugin_LoadURL`): `Stop()`, set `captureInProgress = false`, then `PostMessage(hwnd, WM_WEBVIEW_LOAD_URL, 1, (LPARAM)url)` without deleting `url` yet.
+- `wParam == 1`: `Navigate(url)`, then `delete[] url`.
+- If `inst` or `webview` is invalid, `delete[] url` and return (avoid leaks).
+
+`_CWebViewPlugin_LoadURL` continues to post with `wParam == 0` only.
+
+---
+
+### 3. `WM_WEBVIEW_LOAD_HTML`: `Stop()` and clear `captureInProgress` before `NavigateToString`
+
+**Location**: `case WM_WEBVIEW_LOAD_HTML`.
+
+**Reason**: Same as HTTP loads: cancel in-flight navigation and unlock the capture pipeline before replacing document content.
+
+**Change**: Before `NavigateToString`, call `Stop()` and set `captureInProgress = false`.
+
+---
+
+### 4. Relationship to Unity / C# side (out of scope for this C++ file)
+
+- Keep the default `bitmapRefreshCycle = 10` on Windows: unlike iOS-style paths that are closer to native rendering, Windows relies on `CapturePreview` offscreen bitmaps, and more frequent updates cost more CPU/GPU. If the texture still feels laggy, you may **lower** this value (e.g. to `3`) for smoother redraws at the expense of performance, and tune it together with these native fixes.
+- Managed code can add navigation watchdogs (timeouts, `about:blank` sandwich, cache-busting query strings) when `CallOnStarted` repeats without `CallOnLoaded`.
+
+---
+
+### Recommended verification
+
+1. Editor or standalone Windows: switch quickly among several HTTPS sites (including heavy homepages).
+2. Confirm `CallOnLoaded` and on-screen texture both match the last requested URL.
+3. From a slow-loading page, switch to another URL before load finishes; confirm the new page eventually appears without requiring multiple manual retries.
+4. Regression: destroy the WebView while a page is still loading; confirm no new crashes (together with existing Destroy / C# `OnDestroy` fixes if applied).

--- a/plugins/Windows/WebViewPlugin.cpp
+++ b/plugins/Windows/WebViewPlugin.cpp
@@ -314,6 +314,9 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
                                 inst->webview->add_NavigationCompleted(
                                     Callback<ICoreWebView2NavigationCompletedEventHandler>(
                                         [inst](ICoreWebView2* wv, ICoreWebView2NavigationCompletedEventArgs* args) -> HRESULT {
+                                            // Unity posts WM_WEBVIEW_CAPTURE only when captureInProgress is false. If the previous
+                                            // CapturePreview callback is late or stuck, no new frame is captured (texture stays stale).
+                                            inst->captureInProgress = false;
                                             BOOL success = FALSE;
                                             args->get_IsSuccess(&success);
                                             inst->progress = success ? 100 : 0;
@@ -377,8 +380,19 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         return 0;
     }
     case WM_WEBVIEW_LOAD_URL: {
-        if (inst && inst->webview) {
-            wchar_t* url = (wchar_t*)lParam;
+        // wParam 0: Stop + queue Navigate on next message pump (Stop is not always synchronous;
+        // immediate Navigate on a heavy page can be dropped until user retries).
+        // wParam 1: perform Navigate and free url.
+        wchar_t* url = (wchar_t*)lParam;
+        if (!inst || !inst->webview) {
+            delete[] url;
+            return 0;
+        }
+        if (wParam == 0) {
+            inst->webview->Stop();
+            inst->captureInProgress = false;
+            PostMessage(hwnd, WM_WEBVIEW_LOAD_URL, 1, (LPARAM)url);
+        } else {
             inst->webview->Navigate(url);
             delete[] url;
         }
@@ -388,6 +402,8 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         if (inst && inst->webview) {
             wchar_t* html = (wchar_t*)wParam;
             wchar_t* baseUrl = (wchar_t*)lParam;
+            inst->webview->Stop();
+            inst->captureInProgress = false;
             inst->webview->NavigateToString(html);
             delete[] html;
             if (baseUrl) delete[] baseUrl;


### PR DESCRIPTION
Hi,

This change stops in-flight navigation before starting a new one, defers Navigate to the next message pump, and clears the capture gate on navigation completion and explicit loads so CapturePreview can be scheduled again.

Fix the following issues

Problem

On the Windows WebView2 offscreen capture path, rapidly switching between multiple URLs (e.g. A → B → C) can leave the texture stuck showing one page’s content; the on-screen bitmap may stop updating even though navigation continues in the background.

How to reproduce

Navigate from URL A to B (e.g. a heavy homepage such as Yahoo that takes noticeable time to load), then switch to URL C before B finishes loading.
Alternatively, quickly cycle through URLs A, B, and C in succession; the issue tends to appear more often under this pattern.