### PR TITLE
Fix NullReferenceException when launcher activity is missing from Gradle manifest

### DIFF
--- a/dist/package-nofragment/Assets/Plugins/Editor/UnityWebViewPostprocessBuild.cs
+++ b/dist/package-nofragment/Assets/Plugins/Editor/UnityWebViewPostprocessBuild.cs
@@ -350,6 +350,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetExported(bool enabled) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("exported", AndroidXmlNamespace) != ((enabled) ? "true" : "false")) {
             activity.SetAttribute("exported", AndroidXmlNamespace, (enabled) ? "true" : "false");
             changed = true;
@@ -360,6 +363,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetWindowSoftInputMode(string mode) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("windowSoftInputMode", AndroidXmlNamespace) != mode) {
             activity.SetAttribute("windowSoftInputMode", AndroidXmlNamespace, mode);
             changed = true;
@@ -370,6 +376,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetHardwareAccelerated(bool enabled) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("hardwareAccelerated", AndroidXmlNamespace) != ((enabled) ? "true" : "false")) {
             activity.SetAttribute("hardwareAccelerated", AndroidXmlNamespace, (enabled) ? "true" : "false");
             changed = true;
@@ -380,6 +389,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetActivityName(string name) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("name", AndroidXmlNamespace) != name) {
             activity.SetAttribute("name", AndroidXmlNamespace, name);
             changed = true;

--- a/dist/package/Assets/Plugins/Editor/UnityWebViewPostprocessBuild.cs
+++ b/dist/package/Assets/Plugins/Editor/UnityWebViewPostprocessBuild.cs
@@ -350,6 +350,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetExported(bool enabled) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("exported", AndroidXmlNamespace) != ((enabled) ? "true" : "false")) {
             activity.SetAttribute("exported", AndroidXmlNamespace, (enabled) ? "true" : "false");
             changed = true;
@@ -360,6 +363,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetWindowSoftInputMode(string mode) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("windowSoftInputMode", AndroidXmlNamespace) != mode) {
             activity.SetAttribute("windowSoftInputMode", AndroidXmlNamespace, mode);
             changed = true;
@@ -370,6 +376,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetHardwareAccelerated(bool enabled) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("hardwareAccelerated", AndroidXmlNamespace) != ((enabled) ? "true" : "false")) {
             activity.SetAttribute("hardwareAccelerated", AndroidXmlNamespace, (enabled) ? "true" : "false");
             changed = true;
@@ -380,6 +389,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetActivityName(string name) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("name", AndroidXmlNamespace) != name) {
             activity.SetAttribute("name", AndroidXmlNamespace, name);
             changed = true;

--- a/plugins/Editor/UnityWebViewPostprocessBuild.cs
+++ b/plugins/Editor/UnityWebViewPostprocessBuild.cs
@@ -350,6 +350,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetExported(bool enabled) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("exported", AndroidXmlNamespace) != ((enabled) ? "true" : "false")) {
             activity.SetAttribute("exported", AndroidXmlNamespace, (enabled) ? "true" : "false");
             changed = true;
@@ -360,6 +363,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetWindowSoftInputMode(string mode) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("windowSoftInputMode", AndroidXmlNamespace) != mode) {
             activity.SetAttribute("windowSoftInputMode", AndroidXmlNamespace, mode);
             changed = true;
@@ -370,6 +376,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetHardwareAccelerated(bool enabled) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("hardwareAccelerated", AndroidXmlNamespace) != ((enabled) ? "true" : "false")) {
             activity.SetAttribute("hardwareAccelerated", AndroidXmlNamespace, (enabled) ? "true" : "false");
             changed = true;
@@ -380,6 +389,9 @@ internal class AndroidManifest : AndroidXmlDocument {
     internal bool SetActivityName(string name) {
         bool changed = false;
         var activity = GetActivityWithLaunchIntent() as XmlElement;
+        if (activity == null) {
+            return false;
+        }
         if (activity.GetAttribute("name", AndroidXmlNamespace) != name) {
             activity.SetAttribute("name", AndroidXmlNamespace, name);
             changed = true;


### PR DESCRIPTION
Hi,

I encountered this problem while building the Android player in my Unity project.

## Problem
`UnityWebViewPostprocessBuild.OnPostGenerateGradleAndroidProject` calls
`SetExported`, `SetWindowSoftInputMode`, and `SetHardwareAccelerated`, which
all use `GetActivityWithLaunchIntent()` to locate the activity that declares
`MAIN` and `LAUNCHER`.
If the `AndroidManifest.xml` at `GetManifestPath(basePath)` contains **no**
such activity, `GetActivityWithLaunchIntent()` returns `null` and the
following `GetAttribute` calls throw `NullReferenceException`.
As noted in review, this is reproducible when **Custom Main Manifest** is
enabled and the `UnityPlayerActivity` intent-filter (or equivalent launcher
entry) has been removed or commented out, so the merged manifest seen in this
step no longer matches the XPath query. In the default split
`launcher` + `unityLibrary` flow, `unityLibrary` typically still exposes a
non-null launcher activity here, so the failure mode is not “unityLibrary
never has a launcher” but “this manifest snapshot has no MAIN/LAUNCHER
activity.”

## Solution

Return `false` early from the affected helpers when the launcher activity node is not found:

- `SetExported`
- `SetWindowSoftInputMode`
- `SetHardwareAccelerated`
- `SetActivityName` (same failure mode)

No manifest change is needed for modules without a launcher activity; the module that actually declares `MAIN` / `LAUNCHER` still receives the updates.

## Testing
- Confirmed that an Android build that previously hit `NullReferenceException`
  in `SetExported` completes successfully with this change (Unity Editor on
  Windows; project uses a QuickGame / QuickSDK-style setup).
- Agreed with maintainer feedback: default `unityLibrary` manifest in a
  vanilla split project should still resolve `GetActivityWithLaunchIntent()`
  to a non-null node; this patch adds a safe no-op when that is not the case.
- I have not run an isolated minimal repro; the change is limited to
  null-guards when the launcher activity node is absent.