### PR TITLE
Fix osx WKWebView mouse events and offscreen rendering after navigation

### DIFF
--- a/plugins/Mac/Sources/WebView.mm
+++ b/plugins/Mac/Sources/WebView.mm
@@ -42,6 +42,16 @@
     return frameRect;
 }
 
+// Always report the window as visible so WKWebView keeps rendering even when the window is placed offscreen.
+// Otherwise the offscreen window is treated as occluded (not visible) and WebKit suppresses presentation
+// updates (layer commits). As a result, content after a page transition is never committed to the
+// WindowServer, and takeSnapshotWithConfiguration returns the old (pre-transition) content.
+// cf. isViewVisible() in WebKit's PageClientImplMac.mm reads viewWindow.occlusionState directly.
+- (NSWindowOcclusionState)occlusionState
+{
+    return NSWindowOcclusionStateVisible;
+}
+
 @end
 
 // cf. https://stackoverflow.com/questions/26383031/wkwebview-causes-my-view-controller-to-leak/33365424#33365424

--- a/plugins/Mac/Sources/WebView.mm
+++ b/plugins/Mac/Sources/WebView.mm
@@ -89,6 +89,10 @@ static BOOL s_useMetal;
     NSRegularExpression *hookRegex;
     BOOL inRendering;
     int devicePixelRatio0;
+    NSInteger eventNumber0;        // eventNumber for NSEvent (incremented each time to keep it unique)
+    NSInteger clickCount0;         // click count (shared by mouse down/up; used for double-click detection)
+    NSTimeInterval lastClickTime0; // timestamp of the last mouse down (for double-click detection)
+    NSPoint lastClickPos0;         // position of the last mouse down (for double-click detection)
 }
 @end
 
@@ -747,31 +751,59 @@ window.Unity = { \
         return;
     NSView *view = webView;
     NSGraphicsContext *context = [NSGraphicsContext currentContext];
+    // use the real window number (with 0, [event window] becomes nil and breaks AppKit's event routing)
+    NSInteger windowNumber = (window != nil) ? window.windowNumber : 0;
     [self runBlock:^{
+            NSPoint location = NSMakePoint(x, y);
+            NSTimeInterval now = GetCurrentEventTime();
             NSEvent *event;
             switch (mouseState) {
             case 1:
+                // double-click detection (cf. WebKit's updateClickCountForButton; increment if within 1s at the same position)
+                if (now - self->lastClickTime0 < 1.0 && NSEqualPoints(location, self->lastClickPos0)) {
+                    self->clickCount0 += 1;
+                } else {
+                    self->clickCount0 = 1;
+                }
+                self->lastClickTime0 = now;
+                self->lastClickPos0 = location;
                 event = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
-                                           location:NSMakePoint(x, y) modifierFlags:0
-                                          timestamp:GetCurrentEventTime() windowNumber:0
-                                            context:context eventNumber:0 clickCount:1 pressure:1];
-                [view mouseDown:event];
+                                           location:location modifierFlags:0
+                                          timestamp:now windowNumber:windowNumber
+                                            context:context eventNumber:++self->eventNumber0
+                                         clickCount:self->clickCount0 pressure:1];
+                // find the actual target subview via hitTest and dispatch to it (fall back to webView; cf. WebKit)
+                [([view hitTest:location] ?: view) mouseDown:event];
                 break;
             case 2:
                 event = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDragged
-                                           location:NSMakePoint(x, y) modifierFlags:0
-                                          timestamp:GetCurrentEventTime() windowNumber:0
-                                            context:context eventNumber:0 clickCount:0 pressure:1];
+                                           location:location modifierFlags:0
+                                          timestamp:now windowNumber:windowNumber
+                                            context:context eventNumber:++self->eventNumber0
+                                         clickCount:self->clickCount0 pressure:1];
+                // send drags directly to webView so drag-scrolling outside the view works (cf. WebKit)
                 [view mouseDragged:event];
                 break;
             case 3:
+                // keep the mouse up clickCount the same as the mouse down (do not use 0)
                 event = [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp
-                                           location:NSMakePoint(x, y) modifierFlags:0
-                                          timestamp:GetCurrentEventTime() windowNumber:0
-                                            context:context eventNumber:0 clickCount:0 pressure:0];
-                [view mouseUp:event];
+                                           location:location modifierFlags:0
+                                          timestamp:now windowNumber:windowNumber
+                                            context:context eventNumber:++self->eventNumber0
+                                         clickCount:self->clickCount0 pressure:0];
+                [([view hitTest:location] ?: view) mouseUp:event];
                 break;
             default:
+                // mouse move (hover); skip while scrolling (deltaY != 0)
+                if (deltaY == 0) {
+                    event = [NSEvent mouseEventWithType:NSEventTypeMouseMoved
+                                               location:location modifierFlags:0
+                                              timestamp:now windowNumber:windowNumber
+                                                context:context eventNumber:++self->eventNumber0
+                                             clickCount:0 pressure:0];
+                    // note: mouseMoved may be ignored for an offscreen WKWebView
+                    [view mouseMoved:event];
+                }
                 break;
             }
             if (deltaY != 0) {


### PR DESCRIPTION
cf.

* #1225

## Summary

Two fixes for the macOS (osx) WKWebView plugin in the offscreen bitmap-capture path (`plugins/Mac/Sources/WebView.mm`):

1. **Synthetic mouse events** — align `sendMouseEvent` with how WebKit itself drives a WKWebView (`Tools/WebKitTestRunner/mac/EventSenderProxy.mm`). Previously clicks on some sites (e.g. links on github.com) were not handled.
   - use the real window number instead of `0`
   - increment `eventNumber` for each event
   - track `clickCount` and reuse it for mouse up (enables clicks and double-clicks; mouse up previously used `0`)
   - dispatch to the `hitTest:` target subview instead of the top-level WKWebView
   - deliver mouse-move (hover) events, which were previously dropped

2. **Offscreen rendering after navigation** — after a page transition the captured bitmap kept showing the previous page until a reload. The offscreen window was treated as occluded, so WebKit suppressed presentation updates and `takeSnapshotWithConfiguration` returned stale content. `CNSWindow` now overrides `occlusionState` to always report the window as visible, so WebKit keeps rendering. When the web view is hidden via `SetVisibility`, `isHiddenOrHasHiddenAncestor` still throttles rendering, so this does not waste resources while invisible.

## Notes
- Binaries (`WebView.bundle`) are not included in this branch and should be rebuilt/committed via the usual "updated binaries" flow.
- Known limitation: DOM `event.buttons` is still `0` for synthetic events (fixing it would require swizzling `[NSEvent pressedMouseButtons]`); deferred until a site actually needs it.

## Testing
Verified in the sample against `https://github.com/gree/unity-webview/`: the Contributors link now navigates, and the rendered page updates after navigation without a manual reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
